### PR TITLE
Re-enable gzip content-compression for frontend and update some verions

### DIFF
--- a/adoptopenjdk-api-v3-frontend/src/main/resources/application.properties
+++ b/adoptopenjdk-api-v3-frontend/src/main/resources/application.properties
@@ -4,6 +4,7 @@ quarkus.swagger-ui.always-include=true
 quarkus.http.cors=true
 quarkus.http.cors.origins=*
 quarkus.http.cors.methods=GET,PUT,POST
+quarkus.http.enable-compression=true
 quarkus.http.test-port=8080
 
 quarkus.log.console.enable=true

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,8 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <jackson.version>2.12.3</jackson.version>
         <kmongo.version>4.2.6</kmongo.version>
+
+        <restassured.version>4.3.3</restassured.version>
     </properties>
 
     <modules>
@@ -111,13 +113,13 @@
             <dependency>
                 <groupId>io.rest-assured</groupId>
                 <artifactId>rest-assured</artifactId>
-                <version>4.3.1</version>
+                <version>${restassured.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>io.rest-assured</groupId>
                 <artifactId>json-path</artifactId>
-                <version>4.3.1</version>
+                <version>${restassured.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -202,7 +204,7 @@
             <dependency>
                 <groupId>org.jooq</groupId>
                 <artifactId>jooq</artifactId>
-                <version>3.14.8</version>
+                <version>3.14.9</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
According to https://github.com/quarkusio/quarkus/issues/16425#issuecomment-827282950 gzip can be enabled for vert.x-http globally.
Former to the refactoring to resteasy-reactive it was declared on many routes, with this change it becomes active again.

# Checklist

- [x] `mvn clean install` build and test completes