### PR TITLE
Add env var to configure how much monthly tracking data returned

### DIFF
--- a/adoptopenjdk-api-v3-persistence/src/main/kotlin/net/adoptopenjdk/api/v3/DownloadStatsInterface.kt
+++ b/adoptopenjdk-api-v3-persistence/src/main/kotlin/net/adoptopenjdk/api/v3/DownloadStatsInterface.kt
@@ -71,7 +71,8 @@ class DownloadStatsInterface {
     ): List<MonthlyDownloadDiff> {
 
         val periodEnd = to ?: TimeSource.now().withDayOfMonth(1)
-        val periodStart = periodEnd.minusMonths(6).withDayOfMonth(1)
+        val MONTHLY_LIMIT = System.getenv("STATS_MONTHLY_LIMIT")?.toLongOrNull() ?: 6
+        val periodStart = periodEnd.minusMonths(MONTHLY_LIMIT).withDayOfMonth(1)
         val statsSource = source ?: StatsSource.all
 
         val stats = getMonthlyStats(periodStart.minusDays(10), periodEnd.minusDays(1), featureVersion, dockerRepo, jvmImpl, statsSource)


### PR DESCRIPTION
Return 36 months of monthly download tracking data rather than 6 for improved historical analysis.