### PR TITLE
Updates to the marketplace schema

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -11,6 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Login to our Azure subscription.
+        uses: azure/login@v1
+        with:
+         creds: ${{ secrets.AZURE_CREDENTIALS }}
     
       - name: Login to Azure Container Registry
         uses: docker/login-action@v1
@@ -33,12 +38,11 @@ jobs:
           tags: adoptopenjdkacr.azurecr.io/adoptopenjdk-${{ env.NAMESPACE }}:latest
           push: true
 
-      - name: Set the target Azure Kubernetes Service (AKS) cluster. 
-        uses: azure/aks-set-context@v1
+      - name: Set the target Azure Kubernetes Service (AKS) cluster.
+        uses: azure/aks-set-context@v2.0
         with:
-          creds: '${{ secrets.AZURE_CREDENTIALS }}'
-          cluster-name: aksff92
           resource-group: adopt-api
+          cluster-name: aksff92
 
       - name: Redeploy updater-api
         run: kubectl config set-context --current --namespace=${{ env.NAMESPACE }} && kubectl rollout restart deployment updater-api

--- a/marketplace/adoptium-marketplace-schema-tests/src/test/java/net/adoptium/marketplace/schema/DeserializationTest.java
+++ b/marketplace/adoptium-marketplace-schema-tests/src/test/java/net/adoptium/marketplace/schema/DeserializationTest.java
@@ -67,7 +67,9 @@ public class DeserializationTest {
                         "OpenJDK17U-sources_17.0.1_12.tar.gz",
                         "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.1%2B12/OpenJDK17U-sources_17.0.1_12.tar.gz",
                         105458676l
-                    )
+                    ),
+                    "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_x64_linux_hotspot_17_35.tar.gz.aqavit.zip",
+                    "https://adoptium.net/tck_affidavit.html"
                 )
             )
         );

--- a/marketplace/adoptium-marketplace-schema/src/main/java/net/adoptium/marketplace/schema/JvmImpl.java
+++ b/marketplace/adoptium-marketplace-schema/src/main/java/net/adoptium/marketplace/schema/JvmImpl.java
@@ -6,7 +6,8 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 /*
     Use a schema ref as adopt and adoptium will have a different subset of implementations
 */
-@Schema(type = SchemaType.STRING, enumeration = {"hotspot"})
+@Schema(type = SchemaType.STRING, enumeration = {"hotspot", "openj9"})
 public enum JvmImpl {
-    hotspot;
+    hotspot,
+    openj9;
 }

--- a/marketplace/adoptium-marketplace-schema/src/main/java/net/adoptium/marketplace/schema/Project.java
+++ b/marketplace/adoptium-marketplace-schema/src/main/java/net/adoptium/marketplace/schema/Project.java
@@ -8,13 +8,9 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
         name = "project",
         description = "Project",
         defaultValue = "jdk",
-        enumeration = {"jdk", "valhalla", "metropolis", "jfr", "shenandoah"},
+        enumeration = {"jdk"},
         required = false
 )
 public enum Project {
-    jdk,
-    valhalla,
-    metropolis,
-    jfr,
-    shenandoah;
+    jdk;
 }

--- a/marketplace/adoptium-marketplace-schema/src/main/java/net/adoptium/marketplace/schema/Release.java
+++ b/marketplace/adoptium-marketplace-schema/src/main/java/net/adoptium/marketplace/schema/Release.java
@@ -29,6 +29,12 @@ public class Release {
 
     private final SourcePackage source;
 
+    @Schema(required = true, example = "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_x64_linux_hotspot_17_35.tar.gz.aqavit.zip")
+    private final String aqavit_results_link;
+    
+    @Schema(example = "https://adoptium.net/tck_affidavit.html")
+    private final String tck_affidavit_link;
+
     @JsonCreator
     public Release(
             @JsonProperty("release_link") String release_link,
@@ -38,7 +44,9 @@ public class Release {
             @JsonProperty("binaries") List<Binary> binaries,
             @JsonProperty("vendor") Vendor vendor,
             @JsonProperty("version_data") VersionData version_data,
-            @JsonProperty("source") SourcePackage source
+            @JsonProperty("source") SourcePackage source,
+            @JsonProperty("aqavit_results_link") String aqavit_results_link,
+            @JsonProperty("tck_affidavit_link") String tck_affidavit_link
     ) {
         this.release_link = release_link;
         this.release_name = release_name;
@@ -48,6 +56,8 @@ public class Release {
         this.vendor = vendor;
         this.version_data = version_data;
         this.source = source;
+        this.aqavit_results_link = aqavit_results_link;
+        this.tck_affidavit_link = tck_affidavit_link;
     }
 
 
@@ -81,5 +91,13 @@ public class Release {
 
     public SourcePackage getSource() {
         return source;
+    }
+
+    public String getAqavit_results_link() {
+        return aqavit_results_link;
+    }
+
+    public String getTck_affidavit_link() {
+        return tck_affidavit_link;
     }
 }

--- a/marketplace/adoptium-marketplace-schema/src/main/java/net/adoptium/marketplace/schema/Vendor.java
+++ b/marketplace/adoptium-marketplace-schema/src/main/java/net/adoptium/marketplace/schema/Vendor.java
@@ -1,10 +1,5 @@
 package net.adoptium.marketplace.schema;
 
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
-
-/*
-    Use a schema ref as adopt and adoptium will have a different subset of vendors
-*/
 public enum Vendor {
     adoptium, redhat, alibaba, ibm, azul;
 }

--- a/marketplace/adoptium-marketplace-schema/src/main/java/net/adoptium/marketplace/schema/Vendor.java
+++ b/marketplace/adoptium-marketplace-schema/src/main/java/net/adoptium/marketplace/schema/Vendor.java
@@ -6,5 +6,5 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
     Use a schema ref as adopt and adoptium will have a different subset of vendors
 */
 public enum Vendor {
-    adoptium, redhat, alibaba, ibm;
+    adoptium, redhat, alibaba, ibm, azul;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -17,18 +17,18 @@
         <jdk.version>17</jdk.version>
         <kotlin.compiler.jvmTarget>17</kotlin.compiler.jvmTarget>
         <kotlin.version>1.6.10</kotlin.version>
-        <coroutine.version>1.5.2</coroutine.version>
+        <coroutine.version>1.6.0</coroutine.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.testSource>17</maven.compiler.testSource>
         <maven.compiler.testTarget>17</maven.compiler.testTarget>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.version>2.7.0.Final</quarkus.version>
-        <rest-assured.version>4.5.0</rest-assured.version>
+        <quarkus.version>2.7.1.Final</quarkus.version>
+        <rest-assured.version>4.5.1</rest-assured.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <jackson.version>2.13.1</jackson.version>
-        <kmongo.version>4.4.0</kmongo.version>
+        <kmongo.version>4.5.0</kmongo.version>
     </properties>
 
     <modules>
@@ -182,7 +182,7 @@
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-test-junit5</artifactId>
-                <version>1.6.0</version>
+                <version>1.6.10</version>
             </dependency>
             <!-- Explicitly adding this because Maven can't see it via the kmongo dep -->
             <dependency>
@@ -204,7 +204,7 @@
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>3.21.0</version>
+                <version>3.22.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -221,12 +221,12 @@
             <dependency>
                 <groupId>org.jooq</groupId>
                 <artifactId>jooq</artifactId>
-                <version>3.15.5</version>
+                <version>3.16.4</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.32</version>
+                <version>1.7.36</version>
             </dependency>
             <dependency>
                 <groupId>org.skyscreamer</groupId>
@@ -237,7 +237,7 @@
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>applicationinsights-core</artifactId>
-                <version>2.6.3</version>
+                <version>2.6.4</version>
             </dependency>
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
@@ -333,7 +333,7 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>4.5.0.0</version>
+                    <version>4.5.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>com.ning.maven.plugins</groupId>
@@ -354,7 +354,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.9.0</version>
+                    <version>3.10.0</version>
                     <configuration>
                         <source>${maven.compiler.source}</source>
                         <testSource>${maven.compiler.testSource}</testSource>
@@ -431,7 +431,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.3.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -446,7 +446,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-pmd-plugin</artifactId>
-                    <version>3.15.0</version>
+                    <version>3.16.0</version>
                     <configuration>
                         <targetJdk>${jdk.version}</targetJdk>
                     </configuration>
@@ -454,7 +454,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -469,7 +469,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-scm-plugin</artifactId>
-                    <version>1.12.0</version>
+                    <version>1.12.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -479,7 +479,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.9.1</version>
+                    <version>3.11.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -586,7 +586,7 @@
                 <plugin>
                     <groupId>org.pitest</groupId>
                     <artifactId>pitest-maven</artifactId>
-                    <version>1.7.3</version>
+                    <version>1.7.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -757,7 +757,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.5.0.0</version>
+                <version>4.5.3.0</version>
                 <configuration>
                     <plugins>
                         <plugin>
@@ -801,7 +801,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.15.0</version>
+                <version>3.16.0</version>
                 <configuration>
                     <targetJdk>${jdk.version}</targetJdk>
                 </configuration>
@@ -809,7 +809,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.2.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.rat</groupId>


### PR DESCRIPTION
 - allow for OpenJ9 based JVMs in the marketplace
 - add Azul to vendor list
 - remove non-jck project releases
 - add links for AQAvit results, and TCK statement