### PR TITLE
Stop updating Adoptopenjdk repositories

### DIFF
--- a/adoptium-models-parent/adoptium-api-v3-models/src/main/kotlin/net/adoptium/api/v3/config/APIConfig.kt
+++ b/adoptium-models-parent/adoptium-api-v3-models/src/main/kotlin/net/adoptium/api/v3/config/APIConfig.kt
@@ -6,5 +6,7 @@ class APIConfig {
         val DEBUG: Boolean = System.getenv("DEBUG")?.toBoolean() ?: false
 
         var DISABLE_UPDATER: Boolean = System.getenv("DISABLE_UPDATER")?.toBoolean() ?: false
+
+        var UPDATE_ADOPTOPENJDK: Boolean = System.getenv("UPDATE_ADOPTOPENJDK")?.toBoolean() ?: false
     }
 }

--- a/adoptium-models-parent/adoptium-api-v3-models/src/main/kotlin/net/adoptium/api/v3/dataSources/models/AdoptRepos.kt
+++ b/adoptium-models-parent/adoptium-api-v3-models/src/main/kotlin/net/adoptium/api/v3/dataSources/models/AdoptRepos.kt
@@ -77,8 +77,16 @@ class AdoptRepos {
             .filter { it.binaries.isNotEmpty() }
     }
 
+    fun addAll(releases: List<Release>): AdoptRepos {
+        if (releases.isEmpty()) {
+            return this
+        }
+        return releases
+            .fold(this) { repoAcc, oldRelease -> repoAcc.addRelease(oldRelease.version_data.major, oldRelease) }
+    }
+
     fun addRelease(i: Int, r: Release): AdoptRepos {
-        return AdoptRepos(repos.plus(Pair(i, repos.getValue(i).add(listOf(r)))))
+        return AdoptRepos(repos.plus(Pair(i, repos.getOrDefault(i, FeatureRelease(i, emptyList())).add(listOf(r)))))
     }
 
     fun removeRelease(i: Int, r: Release): AdoptRepos {

--- a/adoptium-updater-parent/adoptium-api-v3-updater/pom.xml
+++ b/adoptium-updater-parent/adoptium-api-v3-updater/pom.xml
@@ -198,6 +198,9 @@
     <profiles>
         <profile>
             <id>adoptopenjdk</id>
+            <properties>
+                <adoptopenjdktests>true</adoptopenjdktests>
+            </properties>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>

--- a/adoptium-updater-parent/adoptium-api-v3-updater/src/main/kotlin/net/adoptium/api/v3/V3Updater.kt
+++ b/adoptium-updater-parent/adoptium-api-v3-updater/src/main/kotlin/net/adoptium/api/v3/V3Updater.kt
@@ -253,8 +253,7 @@ class V3Updater @Inject constructor(
 
                 val newRepoData = adoptReposBuilder.build(Versions.versions)
 
-                // AdoptOpenJdk are excluded from full update,
-                val repo = copyOldReleasesIntoNewRepo(currentRepo, newRepoData)
+                val repo = carryOverExcludedReleases(currentRepo, newRepoData)
 
                 val checksum = calculateChecksum(repo)
 
@@ -277,6 +276,14 @@ class V3Updater @Inject constructor(
             throw e
         }
         return null
+    }
+
+    // Releases that were excluded from the update due to being archived, copy them over from existing data
+    private fun carryOverExcludedReleases(currentRepo: AdoptRepos, newRepoData: AdoptRepos) = if (!APIConfig.UPDATE_ADOPTOPENJDK) {
+        // AdoptOpenJdk were excluded from full update so copy them from previous
+        copyOldReleasesIntoNewRepo(currentRepo, newRepoData)
+    } else {
+        newRepoData
     }
 
 

--- a/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/V3UpdaterTest.kt
+++ b/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/V3UpdaterTest.kt
@@ -2,9 +2,13 @@ package net.adoptium.api
 
 import kotlinx.coroutines.runBlocking
 import net.adoptium.api.v3.V3Updater
-import org.junit.jupiter.api.Test
-import org.slf4j.LoggerFactory
+import net.adoptium.api.v3.dataSources.models.AdoptRepos
+import net.adoptium.api.v3.models.Vendor
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import org.slf4j.LoggerFactory
 
 class V3UpdaterTest {
 
@@ -18,6 +22,33 @@ class V3UpdaterTest {
         runBlocking {
             val checksum = V3Updater.calculateChecksum(BaseTest.adoptRepos)
             assertTrue(checksum.length == 24)
+        }
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = "adoptopenjdktests", matches = "true")
+    fun `adoptOpenJdk releases are copied over`() {
+
+        runBlocking {
+            val repo = AdoptReposTestDataGenerator.generate();
+
+            val adoptopenjdk = AdoptRepos(emptyList()).addAll(repo
+                .allReleases
+                .getReleases()
+                .filter { it.vendor == Vendor.adoptopenjdk }
+                .toList()
+            )
+
+            val notAdoptopenjdk = AdoptRepos(emptyList()).addAll(repo
+                .allReleases
+                .getReleases()
+                .filter { it.vendor != Vendor.adoptopenjdk }
+                .toList()
+            )
+
+            val concated = V3Updater.copyOldReleasesIntoNewRepo(adoptopenjdk, notAdoptopenjdk)
+
+            Assertions.assertEquals(repo, concated)
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

Since AdoptOpenJDK repositories are effectively archived, it is expensive to keep polling and update them every full update cycle. This treats them as set in stone, stops polling for updates, and simply carries forward the existing AdoptOpenJDK data.

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] You added tests to cover the change
- [ ] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation