### PR TITLE
feat: add support for sbom and sbom metadata file_

### DIFF
--- a/adoptium-updater-parent/adoptium-mappers-parent/adopt-mappers/src/main/kotlin/net/adoptium/api/v3/mapping/adopt/AdoptReleaseMapper.kt
+++ b/adoptium-updater-parent/adoptium-mappers-parent/adopt-mappers/src/main/kotlin/net/adoptium/api/v3/mapping/adopt/AdoptReleaseMapper.kt
@@ -230,8 +230,8 @@ private class AdoptReleaseMapper constructor(
         val binaryAsset = releaseAssets
             .assets
             .filter { asset -> !asset.name.endsWith(".json") || ( asset.name.contains("sbom") && !asset.name.endsWith("-metadata.json"))}
-            .firstOrNull {
-                metadataAsset.name.startsWith(it.name)
+            .firstOrNull { // remove .json for matching, case: sbom.json with sbom-metadata.json 
+                metadataAsset.name.startsWith(it.name.removeSuffix(".json"))
             }
 
         val metadataString = htmlClient.getUrl(metadataAsset.downloadUrl)

--- a/adoptium-updater-parent/adoptium-mappers-parent/adopt-mappers/src/main/kotlin/net/adoptium/api/v3/mapping/adopt/AdoptReleaseMapper.kt
+++ b/adoptium-updater-parent/adoptium-mappers-parent/adopt-mappers/src/main/kotlin/net/adoptium/api/v3/mapping/adopt/AdoptReleaseMapper.kt
@@ -219,7 +219,7 @@ private class AdoptReleaseMapper constructor(
     private suspend fun associateMetadataWithBinaries(releaseAssets: GHAssets): Map<GHAsset, GHMetaData> {
         return releaseAssets
             .assets
-            .filter { it.name.endsWith(".json") }
+            .filter { it.name.endsWith(".json") || ( it.name.contains("sbom") && it.name.endsWith("-metadata.json")) }
             .mapNotNull { metadataAsset ->
                 pairUpBinaryAndMetadata(releaseAssets, metadataAsset)
             }
@@ -229,7 +229,7 @@ private class AdoptReleaseMapper constructor(
     private suspend fun pairUpBinaryAndMetadata(releaseAssets: GHAssets, metadataAsset: GHAsset): Pair<GHAsset, GHMetaData>? {
         val binaryAsset = releaseAssets
             .assets
-            .filter { asset -> !asset.name.endsWith(".json") }
+            .filter { asset -> !asset.name.endsWith(".json") || ( asset.name.contains("sbom") && !asset.name.endsWith("-metadata.json"))}
             .firstOrNull {
                 metadataAsset.name.startsWith(it.name)
             }

--- a/adoptium-updater-parent/adoptium-mappers-parent/adopt-mappers/src/main/kotlin/net/adoptium/api/v3/mapping/adopt/AdoptReleaseMapper.kt
+++ b/adoptium-updater-parent/adoptium-mappers-parent/adopt-mappers/src/main/kotlin/net/adoptium/api/v3/mapping/adopt/AdoptReleaseMapper.kt
@@ -219,7 +219,7 @@ private class AdoptReleaseMapper constructor(
     private suspend fun associateMetadataWithBinaries(releaseAssets: GHAssets): Map<GHAsset, GHMetaData> {
         return releaseAssets
             .assets
-            .filter { it.name.endsWith(".json") || ( it.name.contains("sbom") && it.name.endsWith("-metadata.json")) }
+            .filter { ( it.name.endsWith(".json") && !it.name.contains("sbom") ) || ( it.name.contains("sbom") && it.name.endsWith("-metadata.json") ) }
             .mapNotNull { metadataAsset ->
                 pairUpBinaryAndMetadata(releaseAssets, metadataAsset)
             }


### PR DESCRIPTION
	- sbom binary named as *sbom<XXX>.json
	- sbom metadta named as *sbom<XXX>-metadata.json
	- filter release binary if match:
		- file name not end with .json
		- file name contains 'sbom' but not end with '-metadata.json'
	- filter assets if match_
		- file name end with .json
		- file name contains 'sbom' and end with '-metadata.json'
       - map "asserts" with "binary"
               -  non-sbom, same as before
               - sbom: remove .json as suffix , compare *sbom-metadata.json with *sbom 
[see slack conversation ](https://adoptium.slack.com/archives/CFUJV9XV0/p1655808944201159)
       
Ref: https://github.com/adoptium/ci-jenkins-pipelines/issues/328
Ref2: https://github.com/adoptium/ci-jenkins-pipelines/pull/329

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] You added tests to cover the change
- [ ] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation