### PR TITLE
Add support for Temurin GPG signature retrieval

### DIFF
--- a/adoptium-updater-parent/adoptium-mappers-parent/adopt-mappers/src/main/kotlin/net/adoptium/api/v3/mapping/adopt/AdoptBinaryMapper.kt
+++ b/adoptium-updater-parent/adoptium-mappers-parent/adopt-mappers/src/main/kotlin/net/adoptium/api/v3/mapping/adopt/AdoptBinaryMapper.kt
@@ -89,6 +89,7 @@ class AdoptBinaryMapper @Inject constructor(private val gitHubHtmlClient: GitHub
         val binaryLink = binaryAsset.downloadUrl
         val binarySize = binaryAsset.size
         val binaryChecksumLink = getCheckSumLink(fullAssetList, binaryName)
+        val signatureLink = getSignatureLink(fullAssetList, binaryAsset.name)
         val binaryChecksum: String?
 
         binaryChecksum = if (binaryMetadata != null && binaryMetadata.sha256.isNotEmpty()) {
@@ -106,7 +107,7 @@ class AdoptBinaryMapper @Inject constructor(private val gitHubHtmlClient: GitHub
             binaryChecksum,
             binaryChecksumLink,
             binaryAsset.downloadCount,
-            signature_link = null,
+            signature_link = signatureLink,
             metadata_link = metadataLink
         )
     }
@@ -283,5 +284,12 @@ class AdoptBinaryMapper @Inject constructor(private val gitHubHtmlClient: GitHub
             LOGGER.warn("Failed to fetch checksum $binary_checksum_link", e)
         }
         return null
+    }
+
+    private fun getSignatureLink(assets: List<GHAsset>, binary_name: String): String? {
+        return assets
+            .firstOrNull { asset ->
+                asset.name == "$binary_name.sig"
+            }?.downloadUrl
     }
 }

--- a/adoptium-updater-parent/adoptium-mappers-parent/adopt-mappers/src/main/kotlin/net/adoptium/api/v3/mapping/adopt/AdoptBinaryMapper.kt
+++ b/adoptium-updater-parent/adoptium-mappers-parent/adopt-mappers/src/main/kotlin/net/adoptium/api/v3/mapping/adopt/AdoptBinaryMapper.kt
@@ -133,6 +133,7 @@ class AdoptBinaryMapper @Inject constructor(private val gitHubHtmlClient: GitHub
             }
 
             val metadataLink = getMetadataLink(fullAssetList, installer.name)
+            val signatureLink = getSignatureLink(fullAssetList, installer.name)
 
             Installer(
                 installer.name,
@@ -141,7 +142,7 @@ class AdoptBinaryMapper @Inject constructor(private val gitHubHtmlClient: GitHub
                 checksum,
                 checkSumLink,
                 installer.downloadCount,
-                signature_link = null,
+                signature_link = signatureLink,
                 metadata_link = metadataLink
             )
         }


### PR DESCRIPTION
This will add in the ability to retrieve the `.sig` files used for GPG signing our releases (once I start uploading them!)

Submitting this for now so that any problems during review are resolved.

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] You added tests to cover the change
- [x] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation