### PR TITLE
Reimplement Speccy OpenAPI linting to build CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,5 +47,5 @@ jobs:
       run: |
         npm i -g speccy
         # default values cannot be strings even though ours are
-        sed -E 's/"([0-9]+)"/\1/g' adoptium-api-v3-frontend/META-INF/quarkus-generated-openapi-doc.YAML > openapi.yml
+        sed -E 's/"([0-9]+)"/\1/g' ${{ matrix.ecosystem }}-api-v3-frontend/META-INF/quarkus-generated-openapi-doc.YAML > openapi.yml
         speccy lint openapi.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,10 @@ jobs:
 
     - name: Build app
       run: ./mvnw --batch-mode clean install jacoco:report jacoco:report-aggregate ${{ env.ARGS }}
+
+    - name: Lint openapi doc
+      run: |
+        npm i -g speccy
+        # default values cannot be strings even though ours are
+        sed -E 's/"([0-9]+)"/\1/g' adoptium-api-v3-frontend/META-INF/quarkus-generated-openapi-doc.YAML > openapi.yml
+        speccy lint openapi.yml


### PR DESCRIPTION
This was originally added in https://github.com/AdoptOpenJDK/openjdk-api-v3/pull/324 but appears to have been lost along the way.

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] You added tests to cover the change
- [ ] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation