### PR TITLE
Fix failing docker build

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -14,7 +14,8 @@ RUN     useradd -ms /bin/bash api && \
         mkdir -p /home/api/deployment/lib && \
         mkdir -p /home/api/build && \
         mkdir /tmp/build && \
-        chown -R api: /home/api/
+        chown -R api: /home/api/ && \
+        apt-get update && apt-get -y install openssl
 
 WORKDIR /tmp/build
 


### PR DESCRIPTION
Fixes test failures unable to find libcrypto

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] You added tests to cover the change
- [ ] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation