### PR TITLE
bump Marketplace to run on JDK21

### DIFF
--- a/.github/workflows/build-marketplace.yml
+++ b/.github/workflows/build-marketplace.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-    - uses: actions/setup-java@v2
+    - uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: 'maven'
 
@@ -32,19 +32,19 @@ jobs:
         ../mvnw --batch-mode clean install
 
     - name: Upload yaml schema
-      uses: actions/upload-artifact@v2.3.1
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: schema.yaml
         path: marketplace/adoptium-marketplace-schema/target/generated/openapi.yaml
 
     - name: Upload json schema
-      uses: actions/upload-artifact@v2.3.1
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: schema.json
         path: marketplace/adoptium-marketplace-schema/target/generated/openapi.json
 
     - name: Upload example data
-      uses: actions/upload-artifact@v2.3.1
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: example.json
         path: marketplace/adoptium-marketplace-schema-tests/src/test/resources/net/adoptium/marketplace/schema/example.json

--- a/marketplace/adoptium-marketplace-server/adoptium-repo/docker/Dockerfile
+++ b/marketplace/adoptium-marketplace-server/adoptium-repo/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17 as buildwebsite
+FROM eclipse-temurin:21 as buildwebsite
 
 ARG SIGNING_KEY_PASSWORD
 ENV SIGNING_KEY_PASSWORD ${SIGNING_KEY_PASSWORD}

--- a/marketplace/docker/Dockerfile
+++ b/marketplace/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17
+FROM eclipse-temurin:21
 
 RUN     useradd -ms /bin/bash api && \
         mkdir -p /home/api/deployment/ && \

--- a/marketplace/docker/marketplace.docker
+++ b/marketplace/docker/marketplace.docker
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17
+FROM eclipse-temurin:21
 
 RUN     useradd -ms /bin/bash api && \
         mkdir -p /home/api/deployment/ && \


### PR DESCRIPTION
Fixes some GH action hashes and bumps to JDK21

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] You added tests to cover the change
- [ ] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation