### PR TITLE
Fix inconsistency of the data returned by the API

### DIFF
--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/stats/DownloadStatsResource.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/stats/DownloadStatsResource.kt
@@ -121,16 +121,17 @@ class DownloadStatsResource {
         var releases = release
             .releases
             .getReleases()
+            .filter { it.vendor == Vendor.getDefault() }
 
         if(releaseTypes.isNotEmpty()) {
             releases = releases.filter { releaseTypes.contains(it.release_type) }
         }
+
         if(releaseName != null) {
             releases = releases.filter { it.release_name == releaseName }
         }
 
         return releases
-            .filter { it.vendor == Vendor.getDefault() }
     }
 
     @GET

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/stats/DownloadStatsResource.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/stats/DownloadStatsResource.kt
@@ -89,7 +89,7 @@ class DownloadStatsResource {
     @GET
     @Schema(hidden = true)
     @Path("/total/{feature_version}/{release_name}")
-    @Operation(summary = "Get download stats for feature verson", description = "stats", hidden = true)
+    @Operation(summary = "Get download stats for feature version", description = "stats", hidden = true)
     fun getTotalDownloadStatsForTag(
         @Parameter(name = "feature_version", description = "Feature version (i.e 8, 9, 10...)", required = true)
         @PathParam("feature_version")
@@ -102,6 +102,7 @@ class DownloadStatsResource {
             ?: throw BadRequestException("Unable to find version $featureVersion")
 
         return getAdoptReleases(release)
+            .filter { it.release_type == ReleaseType.ga }
             .filter { it.release_name == releaseName }
             .flatMap { it.binaries.asSequence() }
             .flatMap {

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/stats/DownloadStatsResource.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/stats/DownloadStatsResource.kt
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletionStage
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import jakarta.ws.rs.BadRequestException
+import jakarta.ws.rs.DefaultValue
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
@@ -68,8 +69,11 @@ class DownloadStatsResource {
         @Parameter(name = "feature_version", description = "Feature version (i.e 8, 9, 10...)", required = true)
         @PathParam("feature_version")
         featureVersion: Int,
-        @Parameter(name = "release_types", description = "List of release types to include in computation (i.e &release_types=ga,ea)", required = false)
-        @QueryParam("release_types") releaseTypes: List<ReleaseType> = listOf(ReleaseType.ga)
+
+        @Parameter(name = "release_types", description = "List of release types to include in computation (i.e &release_types=ga&release_types=ea)", required = false)
+        @QueryParam("release_types")
+        @DefaultValue("ga")
+        releaseTypes: List<ReleaseType>?
     ): Map<String, Long> {
         val release = apiDataStore.getAdoptRepos().getFeatureRelease(featureVersion)
             ?: throw BadRequestException("Unable to find version $featureVersion")
@@ -95,11 +99,15 @@ class DownloadStatsResource {
         @Parameter(name = "feature_version", description = "Feature version (i.e 8, 9, 10...)", required = true)
         @PathParam("feature_version")
         featureVersion: Int,
+
         @Parameter(name = "release_name", description = "Release Name i.e jdk-11.0.4+11", required = true)
         @PathParam("release_name")
         releaseName: String,
-        @Parameter(name = "release_types", description = "List of release types to include in computation (i.e &release_types=ga,ea)", required = false)
-        @QueryParam("release_types") releaseTypes: List<ReleaseType> = listOf(ReleaseType.ga)
+
+        @Parameter(name = "release_types", description = "List of release types to include in computation (i.e &release_types=ga&release_types=ea)", required = false)
+        @QueryParam("release_types")
+        @DefaultValue("ga")
+        releaseTypes: List<ReleaseType>?
     ): Map<String, Long> {
         val release = apiDataStore.getAdoptRepos().getFeatureRelease(featureVersion)
             ?: throw BadRequestException("Unable to find version $featureVersion")
@@ -117,13 +125,13 @@ class DownloadStatsResource {
             .toMap()
     }
 
-    private fun getAdoptReleases(release: FeatureRelease, releaseTypes: List<ReleaseType>, releaseName: String?): Sequence<Release> {
+    private fun getAdoptReleases(release: FeatureRelease, releaseTypes: List<ReleaseType>?, releaseName: String?): Sequence<Release> {
         var releases = release
             .releases
             .getReleases()
             .filter { it.vendor == Vendor.getDefault() }
 
-        if(releaseTypes.isNotEmpty()) {
+        if(releaseTypes != null && releaseTypes.isNotEmpty()) {
             releases = releases.filter { releaseTypes.contains(it.release_type) }
         }
 

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/DownloadStatsPathTest.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/DownloadStatsPathTest.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import java.time.format.DateTimeFormatter
 import jakarta.ws.rs.BadRequestException
+import net.adoptium.api.v3.models.ReleaseType
 
 @ExtendWith(value = [DbExtension::class])
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -174,6 +175,7 @@ class DownloadStatsPathTest : FrontendTest() {
             val releases = getReleases()
 
             val release = releases
+                .filter { it.release_type == ReleaseType.ga }
                 .filter { it.vendor == Vendor.getDefault() }
                 .first()
 

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/DownloadStatsPathTest.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/DownloadStatsPathTest.kt
@@ -158,14 +158,14 @@ class DownloadStatsPathTest : FrontendTest() {
 
     @Test
     fun totalVersionReturnsSaneData() {
-        val stats = downloadStatsResource.getTotalDownloadStats(8)
+        val stats = downloadStatsResource.getTotalDownloadStats(8, listOf(ReleaseType.ga))
         assertTrue { return@assertTrue stats.isNotEmpty() && !stats.containsValue(0L) }
     }
 
     @Test
     fun badTotalVersionReturnsSaneData() {
         assertThrows<BadRequestException> {
-            downloadStatsResource.getTotalDownloadStats(101)
+            downloadStatsResource.getTotalDownloadStats(101, listOf(ReleaseType.ga))
         }
     }
 
@@ -179,7 +179,7 @@ class DownloadStatsPathTest : FrontendTest() {
                 .filter { it.vendor == Vendor.getDefault() }
                 .first()
 
-            val stats = downloadStatsResource.getTotalDownloadStatsForTag(release.version_data.major, release.release_name)
+            val stats = downloadStatsResource.getTotalDownloadStatsForTag(release.version_data.major, release.release_name, listOf(ReleaseType.ga))
             assertTrue { return@assertTrue stats.isNotEmpty() && !stats.containsValue(0L) }
         }
     }
@@ -187,7 +187,7 @@ class DownloadStatsPathTest : FrontendTest() {
     @Test
     fun badTotalTagReturnsSaneData() {
         assertThrows<BadRequestException> {
-            downloadStatsResource.getTotalDownloadStatsForTag(101, "fooBar")
+            downloadStatsResource.getTotalDownloadStatsForTag(101, "fooBar", listOf(ReleaseType.ga))
         }
     }
 

--- a/adoptium-models-parent/adoptium-api-v3-models/src/main/kotlin/net/adoptium/api/v3/models/ReleaseType.kt
+++ b/adoptium-models-parent/adoptium-api-v3-models/src/main/kotlin/net/adoptium/api/v3/models/ReleaseType.kt
@@ -3,8 +3,9 @@ package net.adoptium.api.v3.models
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType
 import org.eclipse.microprofile.openapi.annotations.media.Schema
 
-@Schema(type = SchemaType.STRING, defaultValue = "ga", enumeration = ["ga", "ea"])
+@Schema(type = SchemaType.STRING, defaultValue = "ga", enumeration = ["all", "ga", "ea"])
 enum class ReleaseType {
+    all,
     ga,
     ea;
 }

--- a/adoptium-models-parent/adoptium-api-v3-models/src/main/kotlin/net/adoptium/api/v3/models/ReleaseType.kt
+++ b/adoptium-models-parent/adoptium-api-v3-models/src/main/kotlin/net/adoptium/api/v3/models/ReleaseType.kt
@@ -3,9 +3,8 @@ package net.adoptium.api.v3.models
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType
 import org.eclipse.microprofile.openapi.annotations.media.Schema
 
-@Schema(type = SchemaType.STRING, defaultValue = "ga", enumeration = ["all", "ga", "ea"])
+@Schema(type = SchemaType.STRING, defaultValue = "ga", enumeration = ["ga", "ea"])
 enum class ReleaseType {
-    all,
     ga,
     ea;
 }


### PR DESCRIPTION
This PR is to resolve (partially) this issue https://github.com/adoptium/dash.adoptium.net/issues/385
There is some inconsistency in data returned by the API.

Two endpoints do not return same data because they do not filter values in the same way.

Filter is `            .filter { it.release_type == ReleaseType.ga }`

line 67 getTotalDownloadStats() 
:warning:  do not have the filter

and 

line 93 getTotalDownloadStatsForTag()
:heavy_check_mark:  have a filter

:arrow_right: I have added the filter to both function. Maybe I should remove the filter from the second, let me know.


# Checklist
- [x] You added tests to cover the change
- [x] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation