### PR TITLE
fix unchecked cast warnings in build

### DIFF
--- a/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/GraphQLGitHubReleaseClientTest.kt
+++ b/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/GraphQLGitHubReleaseClientTest.kt
@@ -74,7 +74,8 @@ class GraphQLGitHubReleaseClientTest : BaseTest() {
                     val builder = mockk<GraphQLClientResponse<F>>()
 
                     assert(query.query?.contains("a-github-id") == true)
-                    every { builder.data } returns GHReleaseResult(response, RateLimit(0, 5000)) as F
+                    every { builder.data } returns GHReleaseResult(response, RateLimit(0, 5000)) as? F
+                        ?: throw ClassCastException("Invalid cast to GHReleaseResult")
                     every { builder.errors } returns null
                     return builder
                 }
@@ -99,7 +100,8 @@ class GraphQLGitHubReleaseClientTest : BaseTest() {
 
                     assert(query.query?.contains("a-repo-name") == true)
 
-                    every { builder.data } returns QueryData(repo, RateLimit(0, 5000)) as F
+                    every { builder.data } returns QueryData(repo, RateLimit(0, 5000)) as? F
+                        ?: throw ClassCastException("Invalid cast to QueryData")
                     every { builder.errors } returns null
                     return builder
                 }
@@ -143,7 +145,8 @@ class GraphQLGitHubReleaseClientTest : BaseTest() {
 
                     assert(query.query?.contains("a-repo-name") == true)
 
-                    every { builder.data } returns summary as F
+                    every { builder.data } returns summary as? F
+                        ?: throw ClassCastException("Invalid cast to QuerySummaryData")
                     every { builder.errors } returns null
                     return builder
                 }
@@ -168,7 +171,8 @@ class GraphQLGitHubReleaseClientTest : BaseTest() {
 
                     assert(query.query?.contains("a-repo-name") == true)
 
-                    val pageInfo = if ((query.variables as Map<String, String>)["cursorPointer"] != null) {
+                    val unsafeMap = query.variables as? Map<*, *>
+                    val pageInfo = if (unsafeMap?.all { (key, value) -> key is String && value is String } == true && unsafeMap["cursorPointer"] != null) {
                         PageInfo(false, null)
                     } else {
                         PageInfo(true, "next-page-id")
@@ -176,7 +180,8 @@ class GraphQLGitHubReleaseClientTest : BaseTest() {
 
                     val repo = GHRepository(GHReleases(listOf(response), pageInfo))
 
-                    every { builder.data } returns QueryData(repo, RateLimit(0, 5000)) as F
+                    every { builder.data } returns QueryData(repo, RateLimit(0, 5000)) as? F
+                        ?: throw ClassCastException("Invalid cast to QueryData")
                     every { builder.errors } returns null
                     return builder
                 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

```output
Warning:  /home/runner/work/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/GraphQLGitHubReleaseClientTest.kt: (77, 98) Unchecked cast: GHReleaseResult to F
Warning:  /home/runner/work/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/GraphQLGitHubReleaseClientTest.kt: (102, 88) Unchecked cast: QueryData to F
Warning:  /home/runner/work/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/GraphQLGitHubReleaseClientTest.kt: (146, 60) Unchecked cast: QuerySummaryData to F
Warning:  /home/runner/work/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/GraphQLGitHubReleaseClientTest.kt: (171, 57) Unchecked cast: Any? to Map<String, String>
Warning:  /home/runner/work/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/GraphQLGitHubReleaseClientTest.kt: (179, 88) Unchecked cast: QueryData to F
```

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] You added tests to cover the change
- [x] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation