### PR TITLE
Ensure no duplicate is returned

### DIFF
--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/ReleaseListResource.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/ReleaseListResource.kt
@@ -151,6 +151,7 @@ constructor(
             semver
         )
             .map { it.release_name }
+            .distinct()
 
         val pagedReleases = getPage(pageSize, page, releases, showPageCount ?: false)
 


### PR DESCRIPTION
Is it normal that the API endpoint /release_names returns duplicated names ?

![image](https://github.com/adoptium/api.adoptium.net/assets/3774556/ce101084-f484-4350-b834-5be5d52d70d1)

jdk-21.0.1+12 is duplicated

# Checklist
- [ ] You added tests to cover the change
- [x] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation