### PR TITLE
Fix/issue 794 review code of returned data

### DIFF
--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/AssetsResource.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/AssetsResource.kt
@@ -7,8 +7,6 @@ import net.adoptium.api.v3.Pagination.maxPageSize
 import net.adoptium.api.v3.dataSources.APIDataStore
 import net.adoptium.api.v3.dataSources.SortMethod
 import net.adoptium.api.v3.dataSources.SortOrder
-import net.adoptium.api.v3.filters.BinaryFilter
-import net.adoptium.api.v3.filters.ReleaseFilter
 import net.adoptium.api.v3.models.Architecture
 import net.adoptium.api.v3.models.BinaryAssetView
 import net.adoptium.api.v3.models.CLib

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/ReleaseEndpoint.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/ReleaseEndpoint.kt
@@ -2,14 +2,6 @@ package net.adoptium.api.v3.routes
 
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
-import jakarta.ws.rs.BadRequestException
-import jakarta.ws.rs.NotFoundException
-import jakarta.ws.rs.PathParam
-import jakarta.ws.rs.QueryParam
-import jakarta.ws.rs.core.Context
-import jakarta.ws.rs.core.UriInfo
-import net.adoptium.api.v3.OpenApiDocs
-import net.adoptium.api.v3.Pagination
 import net.adoptium.api.v3.dataSources.APIDataStore
 import net.adoptium.api.v3.dataSources.SortMethod
 import net.adoptium.api.v3.dataSources.SortOrder
@@ -27,11 +19,6 @@ import net.adoptium.api.v3.models.Project
 import net.adoptium.api.v3.models.Release
 import net.adoptium.api.v3.models.ReleaseType
 import net.adoptium.api.v3.models.Vendor
-import net.adoptium.api.v3.parser.FailedToParse
-import net.adoptium.api.v3.parser.maven.InvalidVersionSpecificationException
-import org.eclipse.microprofile.openapi.annotations.enums.SchemaType
-import org.eclipse.microprofile.openapi.annotations.media.Schema
-import org.eclipse.microprofile.openapi.annotations.parameters.Parameter
 
 @ApplicationScoped
 class ReleaseEndpoint

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/ReleaseEndpoint.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/ReleaseEndpoint.kt
@@ -3,6 +3,13 @@ package net.adoptium.api.v3.routes
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import jakarta.ws.rs.BadRequestException
+import jakarta.ws.rs.NotFoundException
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.Context
+import jakarta.ws.rs.core.UriInfo
+import net.adoptium.api.v3.OpenApiDocs
+import net.adoptium.api.v3.Pagination
 import net.adoptium.api.v3.dataSources.APIDataStore
 import net.adoptium.api.v3.dataSources.SortMethod
 import net.adoptium.api.v3.dataSources.SortOrder
@@ -11,6 +18,7 @@ import net.adoptium.api.v3.filters.ReleaseFilter
 import net.adoptium.api.v3.filters.VersionRangeFilter
 import net.adoptium.api.v3.models.Architecture
 import net.adoptium.api.v3.models.CLib
+import net.adoptium.api.v3.models.DateTime
 import net.adoptium.api.v3.models.HeapSize
 import net.adoptium.api.v3.models.ImageType
 import net.adoptium.api.v3.models.JvmImpl
@@ -21,6 +29,9 @@ import net.adoptium.api.v3.models.ReleaseType
 import net.adoptium.api.v3.models.Vendor
 import net.adoptium.api.v3.parser.FailedToParse
 import net.adoptium.api.v3.parser.maven.InvalidVersionSpecificationException
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType
+import org.eclipse.microprofile.openapi.annotations.media.Schema
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter
 
 @ApplicationScoped
 class ReleaseEndpoint
@@ -28,10 +39,56 @@ class ReleaseEndpoint
 constructor(
     private val apiDataStore: APIDataStore
 ) {
-    fun getReleases(
+    fun getFeatureReleasesAssets(
+        release_type: ReleaseType?,
+        version: Int,
+        os: OperatingSystem?,
+        arch: Architecture?,
+        image_type: ImageType?,
+        cLib: CLib?,
+        jvm_impl: JvmImpl?,
+        heap_size: HeapSize?,
+        vendor: Vendor?,
+        project: Project?,
+        before: DateTime?,
+        sortOrder: SortOrder?,
+        sortMethod: SortMethod?
+    ): Sequence<Release> {
+        val order = sortOrder ?: SortOrder.DESC
+        val releaseSortMethod = sortMethod ?: SortMethod.DEFAULT
+        val vendorNonNull = vendor ?: Vendor.getDefault()
+
+        val releaseFilter = ReleaseFilter(releaseType = release_type, featureVersion = version, vendor = vendorNonNull, jvm_impl = jvm_impl)
+        val binaryFilter = BinaryFilter(os, arch, image_type, jvm_impl, heap_size, project, before, cLib)
+
+        return apiDataStore
+            .getAdoptRepos()
+            .getFilteredReleases(version, releaseFilter, binaryFilter, order, releaseSortMethod)
+    }
+
+    fun getReleaseNameAssets(
+        vendor: Vendor,
+        releaseName: String,
+        os: OperatingSystem?,
+        arch: Architecture?,
+        image_type: ImageType?,
+        cLib: CLib?,
+        jvm_impl: JvmImpl?,
+        heap_size: HeapSize?,
+        project: Project?
+    ): Sequence<Release> {
+        val releaseFilter = ReleaseFilter(vendor = vendor, releaseName = releaseName.trim(), jvm_impl = jvm_impl)
+        val binaryFilter = BinaryFilter(os, arch, image_type, jvm_impl, heap_size, project, null, cLib)
+
+        return apiDataStore
+            .getAdoptRepos()
+            .getFilteredReleases(releaseFilter, binaryFilter, SortOrder.DESC, SortMethod.DEFAULT)
+    }
+
+    fun getVersionAssets(
+        versionRangeFilter: VersionRangeFilter,
         sortOrder: SortOrder?,
         sortMethod: SortMethod?,
-        version: String?,
         release_type: ReleaseType?,
         vendor: Vendor?,
         lts: Boolean?,
@@ -41,26 +98,35 @@ constructor(
         jvm_impl: JvmImpl?,
         heap_size: HeapSize?,
         project: Project?,
-        cLib: CLib?,
-        semver: Boolean?
+        cLib: CLib?
     ): Sequence<Release> {
         val order = sortOrder ?: SortOrder.DESC
         val vendorNonNull = vendor ?: Vendor.getDefault()
         val releaseSortMethod = sortMethod ?: SortMethod.DEFAULT
 
-        val range = try {
-            VersionRangeFilter(version, semver ?: false)
-        } catch (e: InvalidVersionSpecificationException) {
-            throw BadRequestException("Invalid version range", e)
-        } catch (e: FailedToParse) {
-            throw BadRequestException("Invalid version string", e)
-        }
-
-        val releaseFilter = ReleaseFilter(releaseType = release_type, vendor = vendorNonNull, versionRange = range, lts = lts, jvm_impl = jvm_impl)
+        val releaseFilter = ReleaseFilter(releaseType = release_type, vendor = vendorNonNull, versionRange = versionRangeFilter, lts = lts, jvm_impl = jvm_impl)
         val binaryFilter = BinaryFilter(os = os, arch = arch, imageType = image_type, jvmImpl = jvm_impl, heapSize = heap_size, project = project, cLib = cLib)
 
         return apiDataStore
             .getAdoptRepos()
             .getFilteredReleases(releaseFilter, binaryFilter, order, releaseSortMethod)
+    }
+
+    fun getLatestAssets(
+        version: Int,
+        jvm_impl: JvmImpl,
+        vendor: Vendor?,
+        os: OperatingSystem?,
+        arch: Architecture?,
+        image_type: ImageType?
+    ): Sequence<Release> {
+        val binaryVendor = vendor ?: Vendor.getDefault()
+
+        val releaseFilter = ReleaseFilter(ReleaseType.ga, featureVersion = version, vendor = binaryVendor, jvm_impl = jvm_impl)
+        val binaryFilter = BinaryFilter(os, arch, image_type, jvm_impl, null, null)
+
+        return apiDataStore
+            .getAdoptRepos()
+            .getFilteredReleases(version, releaseFilter, binaryFilter, SortOrder.ASC, SortMethod.DEFAULT)
     }
 }

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/ReleaseListResource.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/ReleaseListResource.kt
@@ -28,6 +28,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponses
 import org.eclipse.microprofile.openapi.annotations.tags.Tag
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
+import jakarta.ws.rs.BadRequestException
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.Produces
@@ -36,6 +37,9 @@ import jakarta.ws.rs.core.Context
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import jakarta.ws.rs.core.UriInfo
+import net.adoptium.api.v3.filters.VersionRangeFilter
+import net.adoptium.api.v3.parser.FailedToParse
+import net.adoptium.api.v3.parser.maven.InvalidVersionSpecificationException
 
 @Tag(name = "Release Info")
 @Path("/v3/info")
@@ -134,10 +138,18 @@ constructor(
         @Context
         uriInfo: UriInfo,
     ): Response {
-        val releases = releaseEndpoint.getReleases(
+        val range = try {
+            VersionRangeFilter(version, semver ?: false)
+        } catch (e: InvalidVersionSpecificationException) {
+            throw BadRequestException("Invalid version range", e)
+        } catch (e: FailedToParse) {
+            throw BadRequestException("Invalid version string", e)
+        }
+
+        val releases = releaseEndpoint.getVersionAssets(
+            range,
             sortOrder,
             sortMethod,
-            version,
             release_type,
             vendor,
             lts,
@@ -147,8 +159,7 @@ constructor(
             jvm_impl,
             heap_size,
             project,
-            cLib,
-            semver
+            cLib
         )
             .map { it.release_name }
             .distinct()
@@ -245,10 +256,18 @@ constructor(
         @Context
         uriInfo: UriInfo,
     ): Response {
-        val releases = releaseEndpoint.getReleases(
+        val range = try {
+            VersionRangeFilter(version, semver ?: false)
+        } catch (e: InvalidVersionSpecificationException) {
+            throw BadRequestException("Invalid version range", e)
+        } catch (e: FailedToParse) {
+            throw BadRequestException("Invalid version string", e)
+        }
+
+        val releases = releaseEndpoint.getVersionAssets(
+            range,
             sortOrder,
             sortMethod,
-            version,
             release_type,
             vendor,
             lts,
@@ -258,8 +277,7 @@ constructor(
             jvm_impl,
             heap_size,
             project,
-            cLib,
-            semver
+            cLib
         )
             .map { it.version_data }
             .distinct()

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/packages/BinaryResource.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/packages/BinaryResource.kt
@@ -174,7 +174,7 @@ class BinaryResource @Inject constructor(private val packageEndpoint: PackageEnd
     @Path("/latest/{feature_version}/{release_type}/{os}/{arch}/{image_type}/{jvm_impl}/{heap_size}/{vendor}")
     @Produces("application/octet-stream")
     @Operation(
-        operationId = "getBinary",
+        operationId = "getLatestBinary",
         summary = "Redirects to the binary that matches your current query",
         description = "Redirects to the binary that matches your current query"
     )
@@ -229,10 +229,8 @@ class BinaryResource @Inject constructor(private val packageEndpoint: PackageEnd
         @QueryParam("project")
         project: Project?
     ): Response {
-        val releaseList = packageEndpoint.getRelease(release_type, version, vendor, os, arch, image_type, jvm_impl, heap_size, project, cLib)
-
-        val release = releaseList.lastOrNull()
-
+        val release = packageEndpoint.getReleasesOrderByNewest(release_type, version, vendor, os, arch, image_type, jvm_impl, heap_size, project, cLib)
+            .lastOrNull()
         return formResponse(if (release == null) emptyList() else listOf(release))
     }
 

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/packages/InstallerResource.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/packages/InstallerResource.kt
@@ -154,9 +154,7 @@ class InstallerResource @Inject constructor(private val packageEndpoint: Package
         @QueryParam("project")
         project: Project?
     ): Response {
-        val releaseList = packageEndpoint.getRelease(release_type, version, vendor, os, arch, image_type, jvm_impl, heap_size, project, cLib)
-
-        val release = releaseList
+        val release = packageEndpoint.getReleasesOrderByNewest(release_type, version, vendor, os, arch, image_type, jvm_impl, heap_size, project, cLib)
             .lastOrNull { release ->
                 release.binaries.any { it.installer != null }
             }


### PR DESCRIPTION
As I was looking at the code to understand this issue  https://github.com/adoptium/api.adoptium.net/issues/794, I decided to use this time to improve some pieces of code. Let me know if it was a good idea or not :smile: 

- I have moved up all failures and exceptions at API level in *Resource.kt. (e.g  NotFoundException or BadRequestException caused by invalid VersionRangeFilter)

- I have moved down ReleaseFilter, BinaryFilter, Order and Sort manipulations into *Endpoint.kt level.

I have done those changes to centralize calls to getAdoptRepos() and getFilteredReleases() and to avoid mistakes in the futur. I have also tried to improve the readability.

# Checklist
- [ ] You added tests to cover the change
- [# ] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation