### PR TITLE
Add endpoints for checksum and signature

### DIFF
--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/packages/ChecksumResource.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/packages/ChecksumResource.kt
@@ -1,0 +1,104 @@
+package net.adoptium.api.v3.routes.packages
+
+import net.adoptium.api.v3.OpenApiDocs
+import net.adoptium.api.v3.models.Architecture
+import net.adoptium.api.v3.models.Binary
+import net.adoptium.api.v3.models.CLib
+import net.adoptium.api.v3.models.HeapSize
+import net.adoptium.api.v3.models.ImageType
+import net.adoptium.api.v3.models.JvmImpl
+import net.adoptium.api.v3.models.OperatingSystem
+import net.adoptium.api.v3.models.Project
+import net.adoptium.api.v3.models.Release
+import net.adoptium.api.v3.models.Vendor
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType
+import org.eclipse.microprofile.openapi.annotations.media.Schema
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import net.adoptium.api.v3.models.Package
+
+@Tag(name = "Checksum")
+@Path("/v3/checksum/")
+@Produces(MediaType.APPLICATION_JSON)
+@ApplicationScoped
+class ChecksumResource @Inject constructor(private val packageEndpoint: PackageEndpoint) {
+
+    @GET
+    @Path("/version/{release_name}/{os}/{arch}/{image_type}/{jvm_impl}/{heap_size}/{vendor}")
+    @Produces("application/octet-stream")
+    @Operation(
+        operationId = "getChecksumByVersion",
+        summary = "Redirects to the checksum of the release that matches your current query",
+        description = "Redirects to the checksum of the release that matches your current query"
+    )
+    @APIResponses(
+        value = [
+            APIResponse(responseCode = "307", description = "link to checksum of the release that matches your current query"),
+            APIResponse(responseCode = "400", description = "bad input parameter"),
+            APIResponse(responseCode = "404", description = "No matching signature found")
+        ]
+    )
+    fun returnChecksumByVersion(
+        @Parameter(name = "os", description = "Operating System", required = true)
+        @PathParam("os")
+        os: OperatingSystem?,
+
+        @Parameter(name = "arch", description = "Architecture", required = true)
+        @PathParam("arch")
+        arch: Architecture?,
+
+        @Parameter(
+            name = "release_name", description = OpenApiDocs.RELASE_NAME, required = true,
+            schema = Schema(defaultValue = "jdk-11.0.6+10", type = SchemaType.STRING)
+        )
+        @PathParam("release_name")
+        release_name: String?,
+
+        @Parameter(name = "image_type", description = "Image Type", required = true)
+        @PathParam("image_type")
+        image_type: ImageType?,
+
+        @Parameter(name = "c_lib", description = OpenApiDocs.CLIB_TYPE, required = false)
+        @QueryParam("c_lib")
+        cLib: CLib?,
+
+        @Parameter(name = "jvm_impl", description = "JVM Implementation", required = true)
+        @PathParam("jvm_impl")
+        jvm_impl: JvmImpl?,
+
+        @Parameter(name = "heap_size", description = "Heap Size", required = true)
+        @PathParam("heap_size")
+        heap_size: HeapSize?,
+
+        @Parameter(name = "vendor", description = OpenApiDocs.VENDOR, required = true)
+        @PathParam("vendor")
+        vendor: Vendor?,
+
+        @Parameter(name = "project", description = "Project", required = false)
+        @QueryParam("project")
+        project: Project?
+    ): Response {
+        val releases = packageEndpoint.getReleases(release_name, vendor, os, arch, image_type, jvm_impl, heap_size, project, cLib)
+        return formSignatureResponse(releases)
+    }
+
+    private fun formSignatureResponse(releases: List<Release>): Response {
+        return packageEndpoint.formResponse(releases, extractPackage(), packageEndpoint.redirectToAssetChecksum())
+    }
+
+    private fun extractPackage(): (binary: Binary) -> Package {
+        return { binary -> binary.`package` }
+    }
+}

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/packages/PackageEndpoint.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/packages/PackageEndpoint.kt
@@ -103,4 +103,16 @@ open class PackageEndpoint @Inject constructor(private val apiDataStore: APIData
             Response.temporaryRedirect(URI.create(asset.link)).build()
         }
     }
+
+    open fun redirectToAssetSignature(): (Asset) -> Response {
+        return { asset ->
+            Response.temporaryRedirect(URI.create(asset.signature_link)).build()
+        }
+    }
+
+    open fun redirectToAssetChecksum(): (Asset) -> Response {
+        return { asset ->
+            Response.temporaryRedirect(URI.create(asset.checksum_link)).build()
+        }
+    }
 }

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/packages/SignatureResource.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/packages/SignatureResource.kt
@@ -1,0 +1,104 @@
+package net.adoptium.api.v3.routes.packages
+
+import net.adoptium.api.v3.OpenApiDocs
+import net.adoptium.api.v3.models.Architecture
+import net.adoptium.api.v3.models.Binary
+import net.adoptium.api.v3.models.CLib
+import net.adoptium.api.v3.models.HeapSize
+import net.adoptium.api.v3.models.ImageType
+import net.adoptium.api.v3.models.JvmImpl
+import net.adoptium.api.v3.models.OperatingSystem
+import net.adoptium.api.v3.models.Project
+import net.adoptium.api.v3.models.Release
+import net.adoptium.api.v3.models.Vendor
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType
+import org.eclipse.microprofile.openapi.annotations.media.Schema
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import net.adoptium.api.v3.models.Package
+
+@Tag(name = "Signature")
+@Path("/v3/signature/")
+@Produces(MediaType.APPLICATION_JSON)
+@ApplicationScoped
+class SignatureResource @Inject constructor(private val packageEndpoint: PackageEndpoint) {
+
+    @GET
+    @Path("/version/{release_name}/{os}/{arch}/{image_type}/{jvm_impl}/{heap_size}/{vendor}")
+    @Produces("application/octet-stream")
+    @Operation(
+        operationId = "getSignatureByVersion",
+        summary = "Redirects to the signature of the release that matches your current query",
+        description = "Redirects to the signature of the release that matches your current query"
+    )
+    @APIResponses(
+        value = [
+            APIResponse(responseCode = "307", description = "link to signature of the release that matches your current query"),
+            APIResponse(responseCode = "400", description = "bad input parameter"),
+            APIResponse(responseCode = "404", description = "No matching signature found")
+        ]
+    )
+    fun returnSignatureByVersion(
+        @Parameter(name = "os", description = "Operating System", required = true)
+        @PathParam("os")
+        os: OperatingSystem?,
+
+        @Parameter(name = "arch", description = "Architecture", required = true)
+        @PathParam("arch")
+        arch: Architecture?,
+
+        @Parameter(
+            name = "release_name", description = OpenApiDocs.RELASE_NAME, required = true,
+            schema = Schema(defaultValue = "jdk-11.0.6+10", type = SchemaType.STRING)
+        )
+        @PathParam("release_name")
+        release_name: String?,
+
+        @Parameter(name = "image_type", description = "Image Type", required = true)
+        @PathParam("image_type")
+        image_type: ImageType?,
+
+        @Parameter(name = "c_lib", description = OpenApiDocs.CLIB_TYPE, required = false)
+        @QueryParam("c_lib")
+        cLib: CLib?,
+
+        @Parameter(name = "jvm_impl", description = "JVM Implementation", required = true)
+        @PathParam("jvm_impl")
+        jvm_impl: JvmImpl?,
+
+        @Parameter(name = "heap_size", description = "Heap Size", required = true)
+        @PathParam("heap_size")
+        heap_size: HeapSize?,
+
+        @Parameter(name = "vendor", description = OpenApiDocs.VENDOR, required = true)
+        @PathParam("vendor")
+        vendor: Vendor?,
+
+        @Parameter(name = "project", description = "Project", required = false)
+        @QueryParam("project")
+        project: Project?
+    ): Response {
+        val releases = packageEndpoint.getReleases(release_name, vendor, os, arch, image_type, jvm_impl, heap_size, project, cLib)
+        return formSignatureResponse(releases)
+    }
+
+    private fun formSignatureResponse(releases: List<Release>): Response {
+        return packageEndpoint.formResponse(releases, extractPackage(), packageEndpoint.redirectToAssetSignature())
+    }
+
+    private fun extractPackage(): (binary: Binary) -> Package {
+        return { binary -> binary.`package` }
+    }
+}

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/packages/BinaryPathTest.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/packages/BinaryPathTest.kt
@@ -37,7 +37,7 @@ class BinaryPathTest : PackageEndpointTest() {
         performRequest(path)
             .then()
             .statusCode(307)
-            .header("Location", Matchers.startsWith("https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/"))
+            .header("Location", Matchers.startsWith("https://github.com/adoptium/temurin11-binaries/releases/download/"))
     }
 
     @Test

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/packages/ChecksumPathTest.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/packages/ChecksumPathTest.kt
@@ -1,0 +1,36 @@
+package net.adoptium.api.packages
+
+import io.quarkus.test.junit.QuarkusTest
+import net.adoptium.api.DbExtension
+import net.adoptium.api.v3.models.Architecture
+import net.adoptium.api.v3.models.HeapSize
+import net.adoptium.api.v3.models.ImageType
+import net.adoptium.api.v3.models.JvmImpl
+import net.adoptium.api.v3.models.OperatingSystem
+import net.adoptium.api.v3.models.Project
+import net.adoptium.api.v3.models.Vendor
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@QuarkusTest
+@ExtendWith(value = [DbExtension::class])
+class ChecksumPathTest : PackageEndpointTest() {
+    override fun getPath(): String {
+        return "/v3/checksum"
+    }
+
+    @Test
+    fun versionRequestRedirects() {
+        requestChecksumExpecting307(::getRandomBinary) { release, binary ->
+            getVersionPath(release.release_name, binary.os, binary.architecture, binary.image_type, binary.jvm_impl, binary.heap_size, release.vendor, binary.project)
+        }
+    }
+
+    @Test
+    fun nonExistantVersionRequestGives404() {
+        val path = getVersionPath("fooBar", OperatingSystem.linux, Architecture.x64, ImageType.jdk, JvmImpl.hotspot, HeapSize.normal, Vendor.adoptopenjdk, Project.jdk)
+        performRequest(path)
+            .then()
+            .statusCode(404)
+    }
+}

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/packages/InstallerPathTest.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/packages/InstallerPathTest.kt
@@ -28,7 +28,7 @@ class InstallerPathTest : PackageEndpointTest() {
         performRequest(path)
             .then()
             .statusCode(307)
-            .header("Location", Matchers.startsWith("https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/"))
+            .header("Location", Matchers.startsWith("https://github.com/adoptium/temurin11-binaries/releases/download/"))
     }
 
     @Test
@@ -37,7 +37,7 @@ class InstallerPathTest : PackageEndpointTest() {
         performRequest(path)
             .then()
             .statusCode(307)
-            .header("Location", Matchers.startsWith("https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/"))
+            .header("Location", Matchers.startsWith("https://github.com/adoptium/temurin11-binaries/releases/download/"))
     }
 
     @Test

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/packages/PackageEndpointTest.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/packages/PackageEndpointTest.kt
@@ -108,4 +108,32 @@ abstract class PackageEndpointTest : FrontendTest() {
             .statusCode(307)
             .header("Location", Matchers.startsWith(binary.`package`.link))
     }
+
+    protected fun requestSignatureExpecting307(
+        releaseGetter: (() -> Pair<Release, Binary>),
+        getPath: ((Release, Binary) -> String)
+    ) {
+        val (release, binary) = releaseGetter()
+
+        val path = getPath(release, binary)
+
+        performRequest(path)
+            .then()
+            .statusCode(307)
+            .header("Location", Matchers.startsWith(binary.`package`.signature_link))
+    }
+
+    protected fun requestChecksumExpecting307(
+        releaseGetter: (() -> Pair<Release, Binary>),
+        getPath: ((Release, Binary) -> String)
+    ) {
+        val (release, binary) = releaseGetter()
+
+        val path = getPath(release, binary)
+
+        performRequest(path)
+            .then()
+            .statusCode(307)
+            .header("Location", Matchers.startsWith(binary.`package`.checksum_link))
+    }
 }

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/packages/SignaturePathTest.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/packages/SignaturePathTest.kt
@@ -1,0 +1,36 @@
+package net.adoptium.api.packages
+
+import io.quarkus.test.junit.QuarkusTest
+import net.adoptium.api.DbExtension
+import net.adoptium.api.v3.models.Architecture
+import net.adoptium.api.v3.models.HeapSize
+import net.adoptium.api.v3.models.ImageType
+import net.adoptium.api.v3.models.JvmImpl
+import net.adoptium.api.v3.models.OperatingSystem
+import net.adoptium.api.v3.models.Project
+import net.adoptium.api.v3.models.Vendor
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@QuarkusTest
+@ExtendWith(value = [DbExtension::class])
+class SignaturePathTest : PackageEndpointTest() {
+    override fun getPath(): String {
+        return "/v3/signature"
+    }
+
+    @Test
+    fun versionRequestRedirects() {
+        requestSignatureExpecting307(::getRandomBinary) { release, binary ->
+            getVersionPath(release.release_name, binary.os, binary.architecture, binary.image_type, binary.jvm_impl, binary.heap_size, release.vendor, binary.project)
+        }
+    }
+
+    @Test
+    fun nonExistantVersionRequestGives404() {
+        val path = getVersionPath("fooBar", OperatingSystem.linux, Architecture.x64, ImageType.jdk, JvmImpl.hotspot, HeapSize.normal, Vendor.adoptopenjdk, Project.jdk)
+        performRequest(path)
+            .then()
+            .statusCode(404)
+    }
+}

--- a/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/AdoptReposTestDataGenerator.kt
+++ b/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/AdoptReposTestDataGenerator.kt
@@ -125,12 +125,12 @@ object AdoptReposTestDataGenerator {
             Binary(
                 Package(
                     randomString("package name"),
-                    "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/",
+                    "https://github.com/adoptium/temurin11-binaries/releases/download/",
                     rand.nextLong(),
                     randomString("checksum"),
-                    randomString("checksum link"),
+                    "https://github.com/adoptium/temurin11-binaries/releases/download/",
                     1,
-                    randomString("signature link"),
+                    "https://github.com/adoptium/temurin11-binaries/releases/download/",
                     randomString("metadata link")
                 ),
                 0,
@@ -208,12 +208,12 @@ object AdoptReposTestDataGenerator {
         private fun createPackage(): Package {
             return Package(
                 randomString("package name"),
-                "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/",
+                "https://github.com/adoptium/temurin11-binaries/releases/download/",
                 rand.nextLong(),
                 randomString("checksum"),
-                randomString("checksum link"),
+                "https://github.com/adoptium/temurin11-binaries/releases/download/",
                 1,
-                randomString("signature link"),
+                "https://github.com/adoptium/temurin11-binaries/releases/download/",
                 randomString("metadata link")
             )
         }
@@ -221,12 +221,12 @@ object AdoptReposTestDataGenerator {
         private fun createInstaller(): Installer {
             return Installer(
                 randomString("installer name"),
-                "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/",
+                "https://github.com/adoptium/temurin11-binaries/releases/download/",
                 2,
                 randomString("checksum"),
-                randomString("checksum link"),
+                "https://github.com/adoptium/temurin11-binaries/releases/download/",
                 3,
-                randomString("signature link"),
+                "https://github.com/adoptium/temurin11-binaries/releases/download/",
                 randomString("metadata link")
             )
         }


### PR DESCRIPTION
This PR is related to the issue #853 
I have added to new endpoints that can by used to download checksum or signature of a specific version.

# Checklist
- [X] You added tests to cover the change
- [X] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation