### PR TITLE
Add various usefull endpoints: get supported Architectures & Operating Systems

### DIFF
--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/AvailableArchitecturesResource.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/AvailableArchitecturesResource.kt
@@ -1,0 +1,23 @@
+package net.adoptium.api.v3.routes.info
+
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import net.adoptium.api.v3.models.Architecture
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
+
+@Tag(name = "Release Info")
+@Path("/v3/info")
+@Produces(MediaType.APPLICATION_JSON)
+@ApplicationScoped
+class AvailableArchitecturesResource {
+    @GET
+    @Path("/available_architectures")
+    @Operation(summary = "Returns names of available architectures", operationId = "getAvailableArchitectures")
+    fun get(): List<String> {
+        return Architecture.values().map { it.name }.toList()
+    }
+}

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/AvailableOperatingSystemsResource.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/AvailableOperatingSystemsResource.kt
@@ -1,0 +1,23 @@
+package net.adoptium.api.v3.routes.info
+
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import net.adoptium.api.v3.models.OperatingSystem
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
+
+@Tag(name = "Release Info")
+@Path("/v3/info")
+@Produces(MediaType.APPLICATION_JSON)
+@ApplicationScoped
+class AvailableOperatingSystemsResource {
+    @GET
+    @Path("/available_operating-systems")
+    @Operation(summary = "Returns names of available operating systems", operationId = "getAvailableOperatingSystems")
+    fun get(): List<String> {
+        return OperatingSystem.values().map { it.name }.toList()
+    }
+}

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/AvailableArchitecturesPathTest.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/AvailableArchitecturesPathTest.kt
@@ -1,0 +1,34 @@
+package net.adoptium.api
+
+import io.restassured.RestAssured
+import net.adoptium.api.v3.JsonMapper
+import net.adoptium.api.v3.models.Architecture
+import org.junit.jupiter.api.Test
+
+class AvailableArchitecturesPathTest : FrontendTest() {
+
+    @Test
+    fun availableArchitectures() {
+        RestAssured.given()
+            .`when`()
+            .get("/v3/info/available_architectures")
+            .then()
+            .statusCode(200)
+    }
+
+    @Test
+    fun availableArchitecturesAreCorrect() {
+        var body = RestAssured.given()
+            .`when`()
+            .get("/v3/info/available_architectures")
+            .body
+
+        val architectures = parseArchitectures(body.asString())
+
+        assert(architectures.contains(Architecture.x64.name))
+        assert(architectures.size == Architecture.values().size)
+    }
+
+    private fun parseArchitectures(json: String?): List<String> =
+        JsonMapper.mapper.readValue(json, JsonMapper.mapper.typeFactory.constructCollectionType(MutableList::class.java, String::class.java))
+}

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/AvailableOperatingSystemsPathTest.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/AvailableOperatingSystemsPathTest.kt
@@ -1,0 +1,34 @@
+package net.adoptium.api
+
+import io.restassured.RestAssured
+import net.adoptium.api.v3.JsonMapper
+import net.adoptium.api.v3.models.OperatingSystem
+import org.junit.jupiter.api.Test
+
+class AvailableOperatingSystemsPathTest : FrontendTest() {
+
+    @Test
+    fun availableOperatingSystems() {
+        RestAssured.given()
+            .`when`()
+            .get("/v3/info/available_operating-systems")
+            .then()
+            .statusCode(200)
+    }
+
+    @Test
+    fun availableOperatingSystemsAreCorrect() {
+        var body = RestAssured.given()
+            .`when`()
+            .get("/v3/info/available_operating-systems")
+            .body
+
+        val operatingSystems = parseOperatingSystems(body.asString())
+
+        assert(operatingSystems.contains(OperatingSystem.linux.name))
+        assert(operatingSystems.size == OperatingSystem.values().size)
+    }
+
+    private fun parseOperatingSystems(json: String?): List<String> =
+        JsonMapper.mapper.readValue(json, JsonMapper.mapper.typeFactory.constructCollectionType(MutableList::class.java, String::class.java))
+}


### PR DESCRIPTION
Hello, 

Why not add some usefull endpoints to share more data with users.

Let's start with:
- Supported Architectures
- Support Operating Systems

What do you think?

# Checklist

- [X] You added tests to cover the change
- [X] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation