### PR TITLE
Add two new endpoints and normalize

### DIFF
--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/OpenApiDocs.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/OpenApiDocs.kt
@@ -21,7 +21,7 @@ object OpenApiDocs {
 </p>
 <p>
     Available Feature versions can be obtained from 
-    <a href="${ServerConfig.SERVER}/v3/info/available_releases">${ServerConfig.SERVER}/v3/info/available_releases</a>
+    <a href="${ServerConfig.SERVER}/v3/info/available/releases">${ServerConfig.SERVER}/v3/info/available/releases</a>
 </p>
 """
 

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/AvailableArchitecturesResource.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/AvailableArchitecturesResource.kt
@@ -18,18 +18,6 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag
 class AvailableArchitecturesResource {
 
     @GET
-    @Path("/available_architectures")
-    @Deprecated("Use the new get() method with new path /available/architectures")
-    fun get301(uriInfo: UriInfo): Response {
-        val location = uriInfo.requestUriBuilder.replacePath("/v3/info/available/architectures").build()
-        return Response
-            .status(Response.Status.MOVED_PERMANENTLY)
-            .location(location)
-            .entity(Architecture.values().map { it.name }.toList())
-            .build()
-    }
-
-    @GET
     @Path("/available/architectures")
     @Operation(summary = "Returns names of available architectures", operationId = "getAvailableArchitectures")
     fun get(): List<String> {

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/AvailableArchitecturesResource.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/AvailableArchitecturesResource.kt
@@ -5,6 +5,8 @@ import jakarta.ws.rs.GET
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import jakarta.ws.rs.core.UriInfo
 import net.adoptium.api.v3.models.Architecture
 import org.eclipse.microprofile.openapi.annotations.Operation
 import org.eclipse.microprofile.openapi.annotations.tags.Tag
@@ -14,8 +16,21 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag
 @Produces(MediaType.APPLICATION_JSON)
 @ApplicationScoped
 class AvailableArchitecturesResource {
+
     @GET
     @Path("/available_architectures")
+    @Deprecated("Use the new get() method with new path /available/architectures")
+    fun get301(uriInfo: UriInfo): Response {
+        val location = uriInfo.requestUriBuilder.replacePath("/v3/info/available/architectures").build()
+        return Response
+            .status(Response.Status.MOVED_PERMANENTLY)
+            .location(location)
+            .entity(Architecture.values().map { it.name }.toList())
+            .build()
+    }
+
+    @GET
+    @Path("/available/architectures")
     @Operation(summary = "Returns names of available architectures", operationId = "getAvailableArchitectures")
     fun get(): List<String> {
         return Architecture.values().map { it.name }.toList()

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/AvailableArchitecturesResource.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/AvailableArchitecturesResource.kt
@@ -5,8 +5,6 @@ import jakarta.ws.rs.GET
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.core.MediaType
-import jakarta.ws.rs.core.Response
-import jakarta.ws.rs.core.UriInfo
 import net.adoptium.api.v3.models.Architecture
 import org.eclipse.microprofile.openapi.annotations.Operation
 import org.eclipse.microprofile.openapi.annotations.tags.Tag

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/AvailableOperatingSystemsResource.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/AvailableOperatingSystemsResource.kt
@@ -18,18 +18,6 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag
 class AvailableOperatingSystemsResource {
 
     @GET
-    @Path("/available_operating-systems")
-    @Deprecated("Use the new get() method with new path /available/operating-systems")
-    fun get301(uriInfo: UriInfo): Response {
-        val location = uriInfo.requestUriBuilder.replacePath("/v3/info/available/operating-systems").build()
-        return Response
-            .status(Response.Status.MOVED_PERMANENTLY)
-            .location(location)
-            .entity(OperatingSystem.values().map { it.name }.toList())
-            .build()
-    }
-
-    @GET
     @Path("/available/operating-systems")
     @Operation(summary = "Returns names of available operating systems", operationId = "getAvailableOperatingSystems")
     fun get(): List<String> {

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/AvailableOperatingSystemsResource.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/AvailableOperatingSystemsResource.kt
@@ -5,6 +5,8 @@ import jakarta.ws.rs.GET
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import jakarta.ws.rs.core.UriInfo
 import net.adoptium.api.v3.models.OperatingSystem
 import org.eclipse.microprofile.openapi.annotations.Operation
 import org.eclipse.microprofile.openapi.annotations.tags.Tag
@@ -14,8 +16,21 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag
 @Produces(MediaType.APPLICATION_JSON)
 @ApplicationScoped
 class AvailableOperatingSystemsResource {
+
     @GET
     @Path("/available_operating-systems")
+    @Deprecated("Use the new get() method with new path /available/operating-systems")
+    fun get301(uriInfo: UriInfo): Response {
+        val location = uriInfo.requestUriBuilder.replacePath("/v3/info/available/operating-systems").build()
+        return Response
+            .status(Response.Status.MOVED_PERMANENTLY)
+            .location(location)
+            .entity(OperatingSystem.values().map { it.name }.toList())
+            .build()
+    }
+
+    @GET
+    @Path("/available/operating-systems")
     @Operation(summary = "Returns names of available operating systems", operationId = "getAvailableOperatingSystems")
     fun get(): List<String> {
         return OperatingSystem.values().map { it.name }.toList()

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/AvailableOperatingSystemsResource.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/AvailableOperatingSystemsResource.kt
@@ -5,8 +5,6 @@ import jakarta.ws.rs.GET
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.core.MediaType
-import jakarta.ws.rs.core.Response
-import jakarta.ws.rs.core.UriInfo
 import net.adoptium.api.v3.models.OperatingSystem
 import org.eclipse.microprofile.openapi.annotations.Operation
 import org.eclipse.microprofile.openapi.annotations.tags.Tag

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/AvailableReleasesResource.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/AvailableReleasesResource.kt
@@ -26,6 +26,7 @@ constructor(
     @GET
     @Path("/available_releases")
     @Deprecated("Use the new get() method with new path /available/releases")
+    @Operation(hidden=true)
     fun get301(uriInfo: UriInfo): Response {
         val location = uriInfo.requestUriBuilder.replacePath("/v3/info/available/releases").build()
         return Response

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/AvailableReleasesResource.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/main/kotlin/net/adoptium/api/v3/routes/info/AvailableReleasesResource.kt
@@ -10,6 +10,8 @@ import jakarta.ws.rs.GET
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import jakarta.ws.rs.core.UriInfo
 
 @Tag(name = "Release Info")
 @Path("/v3/info")
@@ -20,8 +22,21 @@ class AvailableReleasesResource
 constructor(
     private val apiDataStore: APIDataStore
 ) {
+
     @GET
     @Path("/available_releases")
+    @Deprecated("Use the new get() method with new path /available/releases")
+    fun get301(uriInfo: UriInfo): Response {
+        val location = uriInfo.requestUriBuilder.replacePath("/v3/info/available/releases").build()
+        return Response
+            .status(Response.Status.MOVED_PERMANENTLY)
+            .location(location)
+            .entity(apiDataStore.getReleaseInfo())
+            .build()
+    }
+
+    @GET
+    @Path("/available/releases")
     @Operation(summary = "Returns information about available releases", operationId = "getAvailableReleases")
     fun get(): ReleaseInfo {
         return apiDataStore.getReleaseInfo()

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/AvailableArchitecturesPathTest.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/AvailableArchitecturesPathTest.kt
@@ -9,16 +9,6 @@ import org.junit.jupiter.api.Test
 class AvailableArchitecturesPathTest : FrontendTest() {
 
     @Test
-    fun availableArchitectures_deprecated() {
-        RestAssured.given()
-            .config(RestAssured.config().redirect(RedirectConfig.redirectConfig().followRedirects(false)))
-            .`when`()
-            .get("/v3/info/available_architectures")
-            .then()
-            .statusCode(301)
-    }
-
-    @Test
     fun availableArchitectures() {
         RestAssured.given()
             .`when`()

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/AvailableArchitecturesPathTest.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/AvailableArchitecturesPathTest.kt
@@ -1,6 +1,7 @@
 package net.adoptium.api
 
 import io.restassured.RestAssured
+import io.restassured.config.RedirectConfig
 import net.adoptium.api.v3.JsonMapper
 import net.adoptium.api.v3.models.Architecture
 import org.junit.jupiter.api.Test
@@ -8,10 +9,20 @@ import org.junit.jupiter.api.Test
 class AvailableArchitecturesPathTest : FrontendTest() {
 
     @Test
+    fun availableArchitectures_deprecated() {
+        RestAssured.given()
+            .config(RestAssured.config().redirect(RedirectConfig.redirectConfig().followRedirects(false)))
+            .`when`()
+            .get("/v3/info/available_architectures")
+            .then()
+            .statusCode(301)
+    }
+
+    @Test
     fun availableArchitectures() {
         RestAssured.given()
             .`when`()
-            .get("/v3/info/available_architectures")
+            .get("/v3/info/available/architectures")
             .then()
             .statusCode(200)
     }
@@ -20,7 +31,7 @@ class AvailableArchitecturesPathTest : FrontendTest() {
     fun availableArchitecturesAreCorrect() {
         var body = RestAssured.given()
             .`when`()
-            .get("/v3/info/available_architectures")
+            .get("/v3/info/available/architectures")
             .body
 
         val architectures = parseArchitectures(body.asString())

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/AvailableArchitecturesPathTest.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/AvailableArchitecturesPathTest.kt
@@ -1,7 +1,6 @@
 package net.adoptium.api
 
 import io.restassured.RestAssured
-import io.restassured.config.RedirectConfig
 import net.adoptium.api.v3.JsonMapper
 import net.adoptium.api.v3.models.Architecture
 import org.junit.jupiter.api.Test

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/AvailableOperatingSystemsPathTest.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/AvailableOperatingSystemsPathTest.kt
@@ -1,7 +1,6 @@
 package net.adoptium.api
 
 import io.restassured.RestAssured
-import io.restassured.config.RedirectConfig
 import net.adoptium.api.v3.JsonMapper
 import net.adoptium.api.v3.models.OperatingSystem
 import org.junit.jupiter.api.Test

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/AvailableOperatingSystemsPathTest.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/AvailableOperatingSystemsPathTest.kt
@@ -1,6 +1,7 @@
 package net.adoptium.api
 
 import io.restassured.RestAssured
+import io.restassured.config.RedirectConfig
 import net.adoptium.api.v3.JsonMapper
 import net.adoptium.api.v3.models.OperatingSystem
 import org.junit.jupiter.api.Test
@@ -8,10 +9,20 @@ import org.junit.jupiter.api.Test
 class AvailableOperatingSystemsPathTest : FrontendTest() {
 
     @Test
+    fun availableOperatingSystems_deprecated() {
+        RestAssured.given()
+            .config(RestAssured.config().redirect(RedirectConfig.redirectConfig().followRedirects(false)))
+            .`when`()
+            .get("/v3/info/available_operating-systems")
+            .then()
+            .statusCode(301)
+    }
+
+    @Test
     fun availableOperatingSystems() {
         RestAssured.given()
             .`when`()
-            .get("/v3/info/available_operating-systems")
+            .get("/v3/info/available/operating-systems")
             .then()
             .statusCode(200)
     }
@@ -20,7 +31,7 @@ class AvailableOperatingSystemsPathTest : FrontendTest() {
     fun availableOperatingSystemsAreCorrect() {
         var body = RestAssured.given()
             .`when`()
-            .get("/v3/info/available_operating-systems")
+            .get("/v3/info/available/operating-systems")
             .body
 
         val operatingSystems = parseOperatingSystems(body.asString())

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/AvailableOperatingSystemsPathTest.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/AvailableOperatingSystemsPathTest.kt
@@ -9,16 +9,6 @@ import org.junit.jupiter.api.Test
 class AvailableOperatingSystemsPathTest : FrontendTest() {
 
     @Test
-    fun availableOperatingSystems_deprecated() {
-        RestAssured.given()
-            .config(RestAssured.config().redirect(RedirectConfig.redirectConfig().followRedirects(false)))
-            .`when`()
-            .get("/v3/info/available_operating-systems")
-            .then()
-            .statusCode(301)
-    }
-
-    @Test
     fun availableOperatingSystems() {
         RestAssured.given()
             .`when`()

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/AvailableReleasesPathTest.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/AvailableReleasesPathTest.kt
@@ -2,6 +2,7 @@ package net.adoptium.api
 
 import io.quarkus.test.junit.QuarkusTest
 import io.restassured.RestAssured
+import io.restassured.config.RedirectConfig
 import net.adoptium.api.v3.JsonMapper
 import net.adoptium.api.v3.models.ReleaseInfo
 import org.hamcrest.Description
@@ -12,10 +13,20 @@ import org.junit.jupiter.api.Test
 class AvailableReleasesPathTest : FrontendTest() {
 
     @Test
+    fun availableReleases_deprecated() {
+        RestAssured.given()
+            .config(RestAssured.config().redirect(RedirectConfig.redirectConfig().followRedirects(false)))
+            .`when`()
+            .get("/v3/info/available_releases")
+            .then()
+            .statusCode(301)
+    }
+
+    @Test
     fun availableReleases() {
         RestAssured.given()
             .`when`()
-            .get("/v3/info/available_releases")
+            .get("/v3/info/available/releases")
             .then()
             .statusCode(200)
     }
@@ -58,7 +69,7 @@ class AvailableReleasesPathTest : FrontendTest() {
     private fun check(matcher: (ReleaseInfo) -> Boolean) {
         RestAssured.given()
             .`when`()
-            .get("/v3/info/available_releases")
+            .get("/v3/info/available/releases")
             .then()
             .body(object : TypeSafeMatcher<String>() {
 

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/JsonSerializationTest.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/JsonSerializationTest.kt
@@ -28,7 +28,7 @@ class JsonSerializationTest : FrontendTest() {
     fun isPrettyPrinted() {
         RestAssured.given()
             .`when`()
-            .get("/v3/info/available_releases")
+            .get("/v3/info/available/releases")
             .then()
             .statusCode(200)
             .body(PrettyPrintMatcher())

--- a/docs/cookbook.adoc
+++ b/docs/cookbook.adoc
@@ -12,7 +12,7 @@ to build more complex queries, including access to nightly builds, debug builds,
 The first example is a simple API query that returns the list of Java versions available from Adoptium, including the regular and long term supported (LTS) versions. The API doesn't take any arguments, and returns a JSON formatted list of versions.
 
 [source,html]
-https://api.adoptium.net/v3/info/available_releases
+https://api.adoptium.net/v3/info/available/releases
 
 open that link in a browser and the result will be something like this
 
@@ -46,7 +46,7 @@ For example, to get the most recent LTS version available you can use:
 
 [source, bash]
 ----
-$ curl -s https://api.adoptium.net/v3/info/available_releases | jq '.most_recent_lts'
+$ curl -s https://api.adoptium.net/v3/info/available/releases | jq '.most_recent_lts'
 17
 ----
 


### PR DESCRIPTION
Changes have been done on paths:
- MOVE /available_releases is now **/available/releases** (deprecated with a 301 redirect to the new location)
- ADD  **/available/architectures**
- ADD  **/available/operating-systems**

**Question**: Do we use /available/operating-systems or /available/operating_systems?
~~**Question 2**: Do you know how to hide an endpoint in this swagger version?~~

# Checklist
- [X] You added tests to cover the change
- [X] `mvn clean install` build and test completes
- [X] You changed or added to the documentation