### PR TITLE
updaste dependabot to use wildcards

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,18 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  # Maintain dependencies for GitHub composite Actions (/.github/actions)
-  # Waiting for supporting wildcards see https://github.com/dependabot/dependabot-core/issues/5137
   - package-ecosystem: "github-actions"
-    directory: "/.github/actions/azure-login"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions/do-login"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions/docker-build"
+    directory: "/.github/actions/*"
     schedule:
       interval: "daily"
   - package-ecosystem: "maven"


### PR DESCRIPTION
now that dependabot supports wildcards (https://github.blog/changelog/2024-06-25-simplified-dependabot-yml-configuration-with-multi-directory-key-directories-and-wildcard-glob-support/)

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] You added tests to cover the change
- [ ] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation