### PR TITLE
Revert "updaste dependabot to use wildcards"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,18 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  # Maintain dependencies for GitHub composite Actions (/.github/actions)
+  # Waiting for supporting wildcards see https://github.com/dependabot/dependabot-core/issues/5137
   - package-ecosystem: "github-actions"
-    directory: "/.github/actions/*"
+    directory: "/.github/actions/azure-login"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/do-login"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/docker-build"
     schedule:
       interval: "daily"
   - package-ecosystem: "maven"


### PR DESCRIPTION
Reverts adoptium/api.adoptium.net#1079

Despite the docs saying dependabot supports wildcards it's broken our config so backing it out for now

![Screenshot 2024-07-03 at 09 48 58](https://github.com/adoptium/api.adoptium.net/assets/20224954/46689ff0-113c-45c8-b2fb-fc62f3e41b21)
