### PR TITLE
Bump io.smallrye:smallrye-open-api-* from 3.10.0 to 3.11.0

### DIFF
--- a/adoptium-api-versions/pom.xml
+++ b/adoptium-api-versions/pom.xml
@@ -343,13 +343,13 @@
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-open-api-core</artifactId>
-                <version>3.10.0</version>
+                <version>3.11.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-open-api-jaxrs</artifactId>
-                <version>3.10.0</version>
+                <version>3.11.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Manuel update for io.smallrye:smallrye-open-api-*

Replace following issues: 
#1069 
#1070 


# Checklist
- [X] `mvn clean install` build and test completes
