### PR TITLE
Bump com.expediagroup:graphql-kotlin-* from 7.1.1 to 7.1.4

### DIFF
--- a/adoptium-api-versions/pom.xml
+++ b/adoptium-api-versions/pom.xml
@@ -411,7 +411,7 @@
             <dependency>
                 <groupId>com.expediagroup</groupId>
                 <artifactId>graphql-kotlin-ktor-client</artifactId>
-                <version>7.1.1</version>
+                <version>7.1.4</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jetbrains.kotlinx</groupId>
@@ -422,7 +422,7 @@
             <dependency>
                 <groupId>com.expediagroup</groupId>
                 <artifactId>graphql-kotlin-client-jackson</artifactId>
-                <version>7.1.1</version>
+                <version>7.1.4</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Manualy fix #1101 

- [ :heavy_check_mark:  ] `mvn clean install` build and test completes
