### PR TITLE
Apply fix to exit updater if the mongodb is not present when the container starts

### DIFF
--- a/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/dataSources/APIDataStore.kt
+++ b/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/dataSources/APIDataStore.kt
@@ -11,4 +11,5 @@ interface APIDataStore {
     fun getReleaseInfo(): ReleaseInfo
     fun loadDataFromDb(forceUpdate: Boolean): AdoptRepos
     fun getUpdateInfo(): UpdatedInfo
+    suspend fun isConnectedToDb(): Boolean
 }

--- a/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/dataSources/APIDataStoreImpl.kt
+++ b/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/dataSources/APIDataStoreImpl.kt
@@ -192,6 +192,10 @@ open class APIDataStoreImpl : APIDataStore {
         return updatedAt
     }
 
+    override suspend fun isConnectedToDb(): Boolean {
+        return dataStore.isConnected()
+    }
+
     // open for
     override fun getAdoptRepos(): AdoptRepos {
         return binaryRepos

--- a/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/dataSources/persitence/ApiPersistence.kt
+++ b/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/dataSources/persitence/ApiPersistence.kt
@@ -32,4 +32,5 @@ interface ApiPersistence {
     suspend fun hasReleaseNotesForGithubId(gitHubId: GitHubId): Boolean
     suspend fun putReleaseNote(releaseNotes: ReleaseNotes)
     suspend fun getReleaseNotes(vendor: Vendor, releaseName: String): ReleaseNotes?
+    suspend fun isConnected(): Boolean
 }

--- a/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/dataSources/persitence/mongo/MongoApiPersistence.kt
+++ b/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/dataSources/persitence/mongo/MongoApiPersistence.kt
@@ -39,6 +39,7 @@ open class MongoApiPersistence @Inject constructor(mongoClient: MongoClient) : M
     private val releaseInfoCollection: MongoCollection<ReleaseInfo> = createCollection(mongoClient.getDatabase(), RELEASE_INFO_DB)
     private val updateTimeCollection: MongoCollection<UpdatedInfo> = createCollection(mongoClient.getDatabase(), UPDATE_TIME_DB)
     private val githubReleaseNotesCollection: MongoCollection<ReleaseNotes> = createCollection(mongoClient.getDatabase(), GH_RELEASE_NOTES)
+    private val client: MongoClient = mongoClient
 
     companion object {
         @JvmStatic
@@ -216,6 +217,10 @@ open class MongoApiPersistence @Inject constructor(mongoClient: MongoClient) : M
         )
         )
             .firstOrNull()
+    }
+
+    override suspend fun isConnected(): Boolean {
+        return client.getDatabase().runCommand(Document("serverStatus", 1)).getDouble("uptime") >= 0
     }
 
     private fun matchGithubId(gitHubId: GitHubId) = Document("gitHubId.id", gitHubId.id)

--- a/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/ApiDataStoreStub.kt
+++ b/adoptium-frontend-parent/adoptium-api-v3-frontend/src/test/kotlin/net/adoptium/api/ApiDataStoreStub.kt
@@ -66,4 +66,8 @@ open class ApiDataStoreStub : APIDataStore {
             123
         )
     }
+
+    override suspend fun isConnectedToDb(): Boolean {
+        return true
+    }
 }

--- a/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/V3UpdaterTest.kt
+++ b/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/V3UpdaterTest.kt
@@ -1,10 +1,17 @@
 package net.adoptium.api
 
-import net.adoptium.api.v3.ReleaseIncludeFilter
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.quarkus.runtime.ApplicationLifecycleManager
+import io.quarkus.runtime.Quarkus
 import kotlinx.coroutines.runBlocking
 import net.adoptium.api.v3.ReleaseFilterType
+import net.adoptium.api.v3.ReleaseIncludeFilter
 import net.adoptium.api.v3.TimeSource
 import net.adoptium.api.v3.V3Updater
+import net.adoptium.api.v3.dataSources.APIDataStore
 import net.adoptium.api.v3.dataSources.models.AdoptRepos
 import net.adoptium.api.v3.models.ReleaseType
 import net.adoptium.api.v3.models.Vendor
@@ -13,12 +20,41 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty
 import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicBoolean
 
 class V3UpdaterTest {
 
     companion object {
         @JvmStatic
         private val LOGGER = LoggerFactory.getLogger(this::class.java)
+    }
+
+    @Test
+    fun `exit is called when db not present`() {
+        runBlocking {
+            val apiDataStore: APIDataStore = mockk()
+            coEvery { apiDataStore.isConnectedToDb() } returns false
+
+            mockkStatic(Quarkus::class)
+            val called = AtomicBoolean(false)
+            every { Quarkus.asyncExit(any()) } answers {
+                called.set(true)
+                ApplicationLifecycleManager.exit(2)
+            }
+
+            val updater = V3Updater(
+                mockk(),
+                apiDataStore,
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk()
+            )
+
+            updater.run(true)
+            assertTrue(called.get())
+        }
     }
 
     @Test

--- a/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/testDoubles/InMemoryApiPersistence.kt
+++ b/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/testDoubles/InMemoryApiPersistence.kt
@@ -116,4 +116,8 @@ open class InMemoryApiPersistence @Inject constructor(var repos: AdoptRepos) : A
             .filter { it.vendor == vendor }
             .firstOrNull { it.release_name == releaseName }
     }
+
+    override suspend fun isConnected(): Boolean {
+        return true
+    }
 }


### PR DESCRIPTION
Fixes #1277 

Applying this in conjunction with applying a health probe to delay the container start until the database is available