### PR TITLE
Add support for jmods ImageType

### DIFF
--- a/adoptium-models-parent/adoptium-api-v3-models/src/main/kotlin/net/adoptium/api/v3/models/ImageType.kt
+++ b/adoptium-models-parent/adoptium-api-v3-models/src/main/kotlin/net/adoptium/api/v3/models/ImageType.kt
@@ -3,7 +3,7 @@ package net.adoptium.api.v3.models
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType
 import org.eclipse.microprofile.openapi.annotations.media.Schema
 
-@Schema(type = SchemaType.STRING, enumeration = ["jdk", "jre", "testimage", "debugimage", "staticlibs", "sources", "sbom"], example = "jdk")
+@Schema(type = SchemaType.STRING, enumeration = ["jdk", "jre", "testimage", "debugimage", "staticlibs", "sources", "sbom", "jmods"], example = "jdk")
 enum class ImageType : FileNameMatcher {
     jdk,
     jre(1),
@@ -11,7 +11,8 @@ enum class ImageType : FileNameMatcher {
     debugimage(1),
     staticlibs(1, "static-libs"),
     sources(1, "sources"),
-    sbom(1);
+    sbom(1),
+    jmods(1);
 
     override lateinit var names: List<String>
     override var priority: Int = 0

--- a/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/AdoptBinaryMapperTest.kt
+++ b/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/AdoptBinaryMapperTest.kt
@@ -519,6 +519,24 @@ class AdoptBinaryMapperTest {
         }
     }
 
+    @Test
+    fun `identifies JMOD images`() {
+        runBlocking {
+            val assets = listOf(
+                GHAsset(
+                    "OpenJDK-jmods_x64_linux_hotspot_2020-11-23-03-35.tar.gz",
+                    1L,
+                    "",
+                    1L,
+                    "2025-02-27T19:35:32Z"
+                )
+            )
+            val binaryList = adoptBinaryMapper.toBinaryList(assets, assets, emptyMap())
+
+            assertEquals(ImageType.jmods, binaryList[0].image_type)
+        }
+    }
+
     private fun assertParsedHotspotJfr(binaryList: List<Binary>) {
         assertEquals(JvmImpl.hotspot, binaryList[0].jvm_impl)
         assertEquals(Project.jfr, binaryList[0].project)


### PR DESCRIPTION
See: https://github.com/adoptium/adoptium-support/issues/1271

Relevant temurin-build change is:
https://github.com/adoptium/temurin-build/pull/4157

JDK 24+ has JEP 493 enabled. For some use-cases JMODs are still required.
Allow for the API to get queried for JMODs for a specific release.