### PR TITLE
Support GitHub immutable releases by including draft releases in API

### DIFF
--- a/adoptium-updater-parent/adoptium-api-v3-updater/src/main/kotlin/net/adoptium/api/v3/AdoptReposBuilder.kt
+++ b/adoptium-updater-parent/adoptium-api-v3-updater/src/main/kotlin/net/adoptium/api/v3/AdoptReposBuilder.kt
@@ -144,7 +144,8 @@ class AdoptReposBuilder @Inject constructor(
             .flatMap { getReleaseById(it) }
     }
 
-    private fun isReleaseOldEnough(timestamp: String): Boolean {
+    private fun isReleaseOldEnough(timestamp: String?): Boolean {
+        if (timestamp == null) return true // Draft releases have no publishedAt, always include them
         val created = ReleaseMapper.parseDate(timestamp)
         return ChronoUnit.MINUTES.between(created, TimeSource.now()).absoluteValue > 10
     }

--- a/adoptium-updater-parent/adoptium-datasources-parent/adoptium-github-datasource/src/main/kotlin/net/adoptium/api/v3/dataSources/github/graphql/clients/GraphQLGitHubReleaseClient.kt
+++ b/adoptium-updater-parent/adoptium-datasources-parent/adoptium-github-datasource/src/main/kotlin/net/adoptium/api/v3/dataSources/github/graphql/clients/GraphQLGitHubReleaseClient.kt
@@ -56,6 +56,7 @@ open class GraphQLGitHubReleaseClient @Inject constructor(
                                         publishedAt,
                                         updatedAt,
                                         isPrerelease,
+                                        isDraft,
                                         resourcePath,
                                         releaseAssets(first:50) {
                                             nodes {

--- a/adoptium-updater-parent/adoptium-datasources-parent/adoptium-github-datasource/src/main/kotlin/net/adoptium/api/v3/dataSources/github/graphql/clients/GraphQLGitHubReleaseRequest.kt
+++ b/adoptium-updater-parent/adoptium-datasources-parent/adoptium-github-datasource/src/main/kotlin/net/adoptium/api/v3/dataSources/github/graphql/clients/GraphQLGitHubReleaseRequest.kt
@@ -51,7 +51,8 @@ open class GraphQLGitHubReleaseRequest @Inject constructor(
                 0
             ),
             release.resourcePath,
-            release.url
+            release.url,
+            release.isDraft
         )
     }
 

--- a/adoptium-updater-parent/adoptium-datasources-parent/adoptium-github-datasource/src/main/kotlin/net/adoptium/api/v3/dataSources/github/graphql/clients/GraphQLGitHubRepositoryClient.kt
+++ b/adoptium-updater-parent/adoptium-datasources-parent/adoptium-github-datasource/src/main/kotlin/net/adoptium/api/v3/dataSources/github/graphql/clients/GraphQLGitHubRepositoryClient.kt
@@ -84,6 +84,7 @@ open class GraphQLGitHubRepositoryClient @Inject constructor(
                                         publishedAt,
                                         updatedAt,
                                         isPrerelease,
+                                        isDraft,
                                         resourcePath,
                                         releaseAssets(first:1) {
                                             totalCount,

--- a/adoptium-updater-parent/adoptium-datasources-parent/adoptium-github-datasource/src/main/kotlin/net/adoptium/api/v3/dataSources/github/graphql/clients/GraphQLGitHubSummaryClient.kt
+++ b/adoptium-updater-parent/adoptium-datasources-parent/adoptium-github-datasource/src/main/kotlin/net/adoptium/api/v3/dataSources/github/graphql/clients/GraphQLGitHubSummaryClient.kt
@@ -64,6 +64,7 @@ open class GraphQLGitHubSummaryClient @Inject constructor(
                                         id,
                                         publishedAt,
                                         updatedAt,
+                                        isDraft,
                                         name,
                                         releaseAssets {
                                             totalCount

--- a/adoptium-updater-parent/adoptium-datasources-parent/adoptium-github-datasource/src/main/kotlin/net/adoptium/api/v3/dataSources/github/graphql/models/GHRelease.kt
+++ b/adoptium-updater-parent/adoptium-datasources-parent/adoptium-github-datasource/src/main/kotlin/net/adoptium/api/v3/dataSources/github/graphql/models/GHRelease.kt
@@ -21,11 +21,12 @@ data class GHRelease @JsonCreator constructor(
     val id: GitHubId,
     @JsonProperty("name") val name: String,
     @JsonProperty("isPrerelease") val isPrerelease: Boolean,
-    @JsonProperty("publishedAt") val publishedAt: String,
+    @JsonProperty("publishedAt") val publishedAt: String?,
     @JsonProperty("updatedAt") val updatedAt: String,
     @JsonProperty("releaseAssets") val releaseAssets: GHAssets,
     @JsonProperty("resourcePath") val resourcePath: String,
-    @JsonProperty("url") val url: String
+    @JsonProperty("url") val url: String,
+    @JsonProperty("isDraft") val isDraft: Boolean = false
 )
 
 data class GHAssets @JsonCreator constructor(

--- a/adoptium-updater-parent/adoptium-datasources-parent/adoptium-github-datasource/src/main/kotlin/net/adoptium/api/v3/dataSources/github/graphql/models/summary/GHReleaseSummary.kt
+++ b/adoptium-updater-parent/adoptium-datasources-parent/adoptium-github-datasource/src/main/kotlin/net/adoptium/api/v3/dataSources/github/graphql/models/summary/GHReleaseSummary.kt
@@ -24,10 +24,11 @@ data class GHReleaseSummary @JsonCreator constructor(
     @JsonProperty("id")
     @JsonDeserialize(using = GitHubIdDeserializer::class)
     val id: GitHubId,
-    @JsonProperty("publishedAt") val publishedAt: String,
+    @JsonProperty("publishedAt") val publishedAt: String?,
     @JsonProperty("updatedAt") val updatedAt: String,
     @JsonProperty("name") val name: String,
-    @JsonProperty("releaseAssets") val releaseAssets: GHAssetsSummary
+    @JsonProperty("releaseAssets") val releaseAssets: GHAssetsSummary,
+    @JsonProperty("isDraft") val isDraft: Boolean = false
 ) {
 
     fun getUpdatedTime(): ZonedDateTime {
@@ -35,7 +36,7 @@ data class GHReleaseSummary @JsonCreator constructor(
     }
 
     fun getPublishedTime(): ZonedDateTime {
-        return parseDate(publishedAt)
+        return parseDate(publishedAt ?: updatedAt)
     }
 
     private fun parseDate(date: String): ZonedDateTime {

--- a/adoptium-updater-parent/adoptium-mappers-parent/adopt-mappers/src/main/kotlin/net/adoptium/api/v3/mapping/adopt/AdoptReleaseMapper.kt
+++ b/adoptium-updater-parent/adoptium-mappers-parent/adopt-mappers/src/main/kotlin/net/adoptium/api/v3/mapping/adopt/AdoptReleaseMapper.kt
@@ -69,7 +69,7 @@ private class AdoptReleaseMapper(
 
         val releaseLink = ghRelease.url
         val releaseName = ghRelease.name
-        val timestamp = parseDate(ghRelease.publishedAt)
+        val timestamp = parseDate(ghRelease.publishedAt ?: ghRelease.updatedAt)
         val updatedAt = parseDate(ghRelease.updatedAt)
 
         val ghAssetsWithMetadata = associateMetadataWithBinaries(ghRelease.releaseAssets)

--- a/adoptium-updater-parent/adoptium-mappers-parent/upstream-mappers/src/main/kotlin/net/adoptium/api/v3/mapping/upstream/UpstreamReleaseMapper.kt
+++ b/adoptium-updater-parent/adoptium-mappers-parent/upstream-mappers/src/main/kotlin/net/adoptium/api/v3/mapping/upstream/UpstreamReleaseMapper.kt
@@ -25,7 +25,7 @@ object UpstreamReleaseMapper : ReleaseMapper() {
 
         val releaseLink = ghRelease.url
         val releaseName = ghRelease.name
-        val timestamp = parseDate(ghRelease.publishedAt)
+        val timestamp = parseDate(ghRelease.publishedAt ?: ghRelease.updatedAt)
         val updatedAt = parseDate(ghRelease.updatedAt)
         val downloadCount = ghRelease.releaseAssets.assets
             .filter { asset ->


### PR DESCRIPTION
GitHub is enabling release immutability, which changes the release workflow: releases will now be created as drafts and only published once all platform artifacts are uploaded. Previously, releases were published immediately and artifacts were added incrementally.

To avoid delays serving binaries while 2nd tier platforms are still being built, the API updater now picks up draft releases alongside published ones.

Changes:
- Add isDraft field to GHRelease and GHReleaseSummary models
- Add isDraft to all GraphQL release queries (repository, summary, release-by-id)
- Make publishedAt nullable (String?) since draft releases have no publishedAt value, falling back to updatedAt in release mappers
- Update AdoptReposBuilder.isReleaseOldEnough() to always include draft releases (which have null publishedAt)
- Pass isDraft through when reconstructing GHRelease after fetching additional release assets

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] You added tests to cover the change
- [x] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation