### PR TITLE
fix(DownloadStatsInterface): Aggregate package download on read

### DIFF
--- a/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/DownloadStatsInterface.kt
+++ b/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/DownloadStatsInterface.kt
@@ -296,15 +296,7 @@ class DownloadStatsInterface {
     private suspend fun getPackageStats(): List<CloudflarePackageDownloadStatsDbEntry> {
         val start = Instant.EPOCH.atZone(TimeSource.ZONE)
         val end = TimeSource.now()
-        return dataStore.getPackageStats(start, end)
-            .groupBy { it.feature_version }
-            .map { (featureVersion, entries) ->
-                CloudflarePackageDownloadStatsDbEntry(
-                    date = entries.maxOf { it.date },
-                    downloads = entries.sumOf { it.downloads },
-                    feature_version = featureVersion
-                )
-            }
+        return dataStore.getAggregatedPackageStats(start, end)
             .filter { it.downloads != 0L }
     }
 }

--- a/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/DownloadStatsInterface.kt
+++ b/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/DownloadStatsInterface.kt
@@ -16,6 +16,7 @@ import net.adoptium.api.v3.models.MonthlyDownloadDiff
 import net.adoptium.api.v3.models.StatsSource
 import net.adoptium.api.v3.models.TotalStats
 import org.eclipse.microprofile.openapi.annotations.media.Schema
+import java.time.Instant
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 import kotlin.math.max
@@ -293,9 +294,16 @@ class DownloadStatsInterface {
     }
 
     private suspend fun getPackageStats(): List<CloudflarePackageDownloadStatsDbEntry> {
-        return versionSupplier.getAllVersions()
-            .mapNotNull { featureVersion ->
-                dataStore.getLatestPackageStatsForFeatureVersion(featureVersion)
+        val start = Instant.EPOCH.atZone(TimeSource.ZONE)
+        val end = TimeSource.now()
+        return dataStore.getPackageStats(start, end)
+            .groupBy { it.feature_version }
+            .map { (featureVersion, entries) ->
+                CloudflarePackageDownloadStatsDbEntry(
+                    date = entries.maxOf { it.date },
+                    downloads = entries.sumOf { it.downloads },
+                    feature_version = featureVersion
+                )
             }
             .filter { it.downloads != 0L }
     }

--- a/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/dataSources/persitence/ApiPersistence.kt
+++ b/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/dataSources/persitence/ApiPersistence.kt
@@ -31,6 +31,7 @@ interface ApiPersistence {
     suspend fun addPackageDownloadStatsEntries(stats: List<CloudflarePackageDownloadStatsDbEntry>)
     suspend fun getLatestPackageStatsForFeatureVersion(featureVersion: Int): CloudflarePackageDownloadStatsDbEntry?
     suspend fun getPackageStats(start: ZonedDateTime, end: ZonedDateTime): List<CloudflarePackageDownloadStatsDbEntry>
+    suspend fun getAggregatedPackageStats(start: ZonedDateTime, end: ZonedDateTime): List<CloudflarePackageDownloadStatsDbEntry>
     suspend fun removeStatsBetween(start: ZonedDateTime, end: ZonedDateTime)
     suspend fun setReleaseInfo(releaseInfo: ReleaseInfo)
     suspend fun getReleaseInfo(): ReleaseInfo?

--- a/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/dataSources/persitence/mongo/MongoApiPersistence.kt
+++ b/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/dataSources/persitence/mongo/MongoApiPersistence.kt
@@ -10,21 +10,21 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import net.adoptium.api.v3.TimeSource
-import net.adoptium.api.v3.dataSources.models.AdoptRepos
 import net.adoptium.api.v3.dataSources.models.AdoptCdxaRepos
+import net.adoptium.api.v3.dataSources.models.AdoptRepos
 import net.adoptium.api.v3.dataSources.models.FeatureRelease
 import net.adoptium.api.v3.dataSources.models.GitHubId
 import net.adoptium.api.v3.dataSources.models.ReleaseNotes
 import net.adoptium.api.v3.dataSources.models.Releases
 import net.adoptium.api.v3.dataSources.persitence.ApiPersistence
-import net.adoptium.api.v3.models.DockerDownloadStatsDbEntry
+import net.adoptium.api.v3.models.Cdxa
 import net.adoptium.api.v3.models.CloudflarePackageDownloadStatsDbEntry
+import net.adoptium.api.v3.models.DockerDownloadStatsDbEntry
 import net.adoptium.api.v3.models.GHReleaseMetadata
 import net.adoptium.api.v3.models.GitHubDownloadStatsDbEntry
 import net.adoptium.api.v3.models.Release
 import net.adoptium.api.v3.models.ReleaseInfo
 import net.adoptium.api.v3.models.Vendor
-import net.adoptium.api.v3.models.Cdxa
 import org.bson.BsonArray
 import org.bson.BsonBoolean
 import org.bson.BsonDateTime
@@ -41,19 +41,21 @@ open class MongoApiPersistence @Inject constructor(mongoClient: MongoClient) : M
     private var cdxasCollection: MongoCollection<Cdxa> = createCollection(mongoClient.getDatabase(), CDXAS_DB)
     private val gitHubStatsCollection: MongoCollection<GitHubDownloadStatsDbEntry> = createCollection(mongoClient.getDatabase(), GITHUB_STATS_DB)
     private val dockerStatsCollection: MongoCollection<DockerDownloadStatsDbEntry> = createCollection(mongoClient.getDatabase(), DOCKER_STATS_DB)
-    private val packageStatsCollection: MongoCollection<CloudflarePackageDownloadStatsDbEntry> = createCollection(mongoClient.getDatabase(), PACKAGE_STATS_DB)
-
-    init {
-        // Create indexes for packageStats if they don't exist
-        try {
-            runBlocking {
-                packageStatsCollection.createIndex(Document("date", 1))
-                packageStatsCollection.createIndex(Document("feature_version", 1).append("date", 1))
+    private val packageStatsCollection: MongoCollection<CloudflarePackageDownloadStatsDbEntry> = createCollection(
+        mongoClient.getDatabase(),
+        PACKAGE_STATS_DB,
+        ensureIndexes = { collection ->
+            // Create indexes for packageStats if they don't exist
+            try {
+                runBlocking {
+                    collection.createIndex(Document("date", 1))
+                    collection.createIndex(Document("feature_version", 1).append("date", 1))
+                }
+            } catch (e: Exception) {
+                LOGGER.warn("Failed to create indexes for packageStats: ${e.message}")
             }
-        } catch (e: Exception) {
-            LOGGER.warn("Failed to create indexes for packageStats: ${e.message}")
-        }
-    }
+        })
+
     private val releaseInfoCollection: MongoCollection<ReleaseInfo> = createCollection(mongoClient.getDatabase(), RELEASE_INFO_DB)
     private val updateTimeCollection: MongoCollection<UpdatedInfo> = createCollection(mongoClient.getDatabase(), UPDATE_TIME_DB)
     private val cdxaUpdateTimeCollection: MongoCollection<UpdatedInfo> = createCollection(mongoClient.getDatabase(), CDXAS_UPDATE_TIME_DB)
@@ -97,7 +99,7 @@ open class MongoApiPersistence @Inject constructor(mongoClient: MongoClient) : M
                 writeCdxas(featureVersion, repo.repos.filter { it.featureVersion == featureVersion })
             }
 
-            removeCdxasNotInFeatureVersions( featureVersions )
+            removeCdxasNotInFeatureVersions(featureVersions)
         } finally {
             updateCdxaUpdatedTime(TimeSource.now(), checksum, repo.hashCode())
         }
@@ -201,18 +203,10 @@ open class MongoApiPersistence @Inject constructor(mongoClient: MongoClient) : M
     }
 
     override suspend fun getAggregatedPackageStats(start: ZonedDateTime, end: ZonedDateTime): List<CloudflarePackageDownloadStatsDbEntry> {
-        val startMillis = start.toInstant().toEpochMilli()
-        val endMillis = end.toInstant().toEpochMilli()
-
         val pipeline = listOf(
             Document(
                 "\$match",
-                Document(
-                    "\$and", listOf(
-                        Document("date", Document("\$gt", BsonDateTime(startMillis))),
-                        Document("date", Document("\$lt", BsonDateTime(endMillis)))
-                    )
-                )
+                betweenDates(start, end)
             ),
             Document(
                 "\$group",

--- a/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/dataSources/persitence/mongo/MongoApiPersistence.kt
+++ b/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/dataSources/persitence/mongo/MongoApiPersistence.kt
@@ -8,6 +8,7 @@ import jakarta.inject.Inject
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
 import net.adoptium.api.v3.TimeSource
 import net.adoptium.api.v3.dataSources.models.AdoptRepos
 import net.adoptium.api.v3.dataSources.models.AdoptCdxaRepos
@@ -41,6 +42,18 @@ open class MongoApiPersistence @Inject constructor(mongoClient: MongoClient) : M
     private val gitHubStatsCollection: MongoCollection<GitHubDownloadStatsDbEntry> = createCollection(mongoClient.getDatabase(), GITHUB_STATS_DB)
     private val dockerStatsCollection: MongoCollection<DockerDownloadStatsDbEntry> = createCollection(mongoClient.getDatabase(), DOCKER_STATS_DB)
     private val packageStatsCollection: MongoCollection<CloudflarePackageDownloadStatsDbEntry> = createCollection(mongoClient.getDatabase(), PACKAGE_STATS_DB)
+
+    init {
+        // Create indexes for packageStats if they don't exist
+        try {
+            runBlocking {
+                packageStatsCollection.createIndex(Document("date", 1))
+                packageStatsCollection.createIndex(Document("feature_version", 1).append("date", 1))
+            }
+        } catch (e: Exception) {
+            LOGGER.warn("Failed to create indexes for packageStats: ${e.message}")
+        }
+    }
     private val releaseInfoCollection: MongoCollection<ReleaseInfo> = createCollection(mongoClient.getDatabase(), RELEASE_INFO_DB)
     private val updateTimeCollection: MongoCollection<UpdatedInfo> = createCollection(mongoClient.getDatabase(), UPDATE_TIME_DB)
     private val cdxaUpdateTimeCollection: MongoCollection<UpdatedInfo> = createCollection(mongoClient.getDatabase(), CDXAS_UPDATE_TIME_DB)
@@ -185,6 +198,44 @@ open class MongoApiPersistence @Inject constructor(mongoClient: MongoClient) : M
 
     override suspend fun addPackageDownloadStatsEntries(stats: List<CloudflarePackageDownloadStatsDbEntry>) {
         packageStatsCollection.insertMany(stats)
+    }
+
+    override suspend fun getAggregatedPackageStats(start: ZonedDateTime, end: ZonedDateTime): List<CloudflarePackageDownloadStatsDbEntry> {
+        val startMillis = start.toInstant().toEpochMilli()
+        val endMillis = end.toInstant().toEpochMilli()
+
+        val pipeline = listOf(
+            Document(
+                "\$match",
+                Document(
+                    "\$and", listOf(
+                        Document("date", Document("\$gt", BsonDateTime(startMillis))),
+                        Document("date", Document("\$lt", BsonDateTime(endMillis)))
+                    )
+                )
+            ),
+            Document(
+                "\$group",
+                mapOf(
+                    "_id" to Document("feature_version", "\$feature_version"),
+                    "downloads" to Document("\$sum", "\$downloads"),
+                    "date" to Document("\$max", "\$date")
+                )
+            ),
+            Document(
+                "\$project",
+                mapOf(
+                    "_id" to 0,
+                    "date" to 1,
+                    "downloads" to 1,
+                    "feature_version" to "\$_id.feature_version"
+                )
+            )
+        )
+
+        return packageStatsCollection.aggregate(pipeline)
+            .toList()
+
     }
 
     override suspend fun getLatestPackageStatsForFeatureVersion(featureVersion: Int): CloudflarePackageDownloadStatsDbEntry? {

--- a/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/dataSources/persitence/mongo/MongoInterface.kt
+++ b/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/dataSources/persitence/mongo/MongoInterface.kt
@@ -15,11 +15,19 @@ abstract class MongoInterface {
         val LOGGER = LoggerFactory.getLogger(MongoInterface::class.java)!!
     }
 
-    inline fun <reified T : Any> createCollection(database: MongoDatabase, collectionName: String): MongoCollection<T> {
+    inline fun <reified T : Any> createCollection(
+        database: MongoDatabase,
+        collectionName: String,
+        //To be used for first collection init only, it will not run if collection already exists
+        crossinline initCollection: (collection: MongoCollection<T>) -> Unit = {},
 
-        runBlocking {
+        // To be used to create any indexes, this must be idempotent and not affect/destroy an existing collection
+        crossinline ensureIndexes: (collection: MongoCollection<T>) -> Unit = {},
+        ): MongoCollection<T> {
+        return runBlocking<MongoCollection<T>> {
             try {
                 database.createCollection(collectionName)
+                initCollection(database.getCollection(collectionName, T::class.java))
             } catch (e: MongoCommandException) {
                 if (e.errorCode == 48) {
                     // collection already exists ... ignore
@@ -30,8 +38,9 @@ abstract class MongoInterface {
                     }
                 }
             }
+            val collection = database.getCollection(collectionName, T::class.java)
+            ensureIndexes(collection)
+            collection
         }
-        return database.getCollection(collectionName, T::class.java)
-
     }
 }

--- a/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/DockerStatsInterfaceTest.kt
+++ b/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/DockerStatsInterfaceTest.kt
@@ -10,7 +10,6 @@ import net.adoptium.api.v3.TimeSource
 import net.adoptium.api.v3.dataSources.DefaultUpdaterHtmlClient
 import net.adoptium.api.v3.dataSources.HttpClientFactory
 import net.adoptium.api.v3.dataSources.persitence.ApiPersistence
-import net.adoptium.api.v3.models.CloudflarePackageDownloadStatsDbEntry
 import net.adoptium.api.v3.models.DockerDownloadStatsDbEntry
 import net.adoptium.api.v3.models.GitHubDownloadStatsDbEntry
 import net.adoptium.api.v3.models.JvmImpl
@@ -100,33 +99,6 @@ class DockerStatsInterfaceTest : BaseTest() {
             assertEquals(14, DockerStats.getOpenjdkVersionFromString("maven-openjdk14-openj9"))
 
             assertEquals(null, DockerStats.getOpenjdkVersionFromString("official"))
-        }
-    }
-
-    @Test
-    fun packageStatsShouldSumDeltasAcrossMinutes() {
-        runBlocking {
-            val apiPersistenceMock = mockk<ApiPersistence>()
-            val baseTime = TimeSource.now()
-
-            coEvery { apiPersistenceMock.getLatestAllDockerStats() } returns emptyList()
-            coEvery { apiPersistenceMock.getLatestGithubStatsForFeatureVersion(any()) } returns null
-            coEvery { apiPersistenceMock.getPackageStats(any<ZonedDateTime>(), any<ZonedDateTime>()) } returns listOf(
-                // Version 17: three minute-level deltas that should sum to 1000
-                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(3), 400, 17),
-                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(2), 350, 17),
-                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(1), 250, 17),
-                // Version 21: two minute-level deltas that should sum to 500
-                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(2), 300, 21),
-                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(1), 200, 21)
-            )
-
-            val downloadStatsInterface = DownloadStatsInterface(apiPersistenceMock, UpdatableVersionSupplierStub())
-            val stats = downloadStatsInterface.getTotalDownloadStats()
-
-            assertEquals(1500L, stats.total_downloads.package_downloads)
-            assertEquals(1000L, stats.package_downloads[17])
-            assertEquals(500L, stats.package_downloads[21])
         }
     }
 }

--- a/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/DockerStatsInterfaceTest.kt
+++ b/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/DockerStatsInterfaceTest.kt
@@ -10,6 +10,7 @@ import net.adoptium.api.v3.TimeSource
 import net.adoptium.api.v3.dataSources.DefaultUpdaterHtmlClient
 import net.adoptium.api.v3.dataSources.HttpClientFactory
 import net.adoptium.api.v3.dataSources.persitence.ApiPersistence
+import net.adoptium.api.v3.models.CloudflarePackageDownloadStatsDbEntry
 import net.adoptium.api.v3.models.DockerDownloadStatsDbEntry
 import net.adoptium.api.v3.models.GitHubDownloadStatsDbEntry
 import net.adoptium.api.v3.models.JvmImpl
@@ -99,6 +100,33 @@ class DockerStatsInterfaceTest : BaseTest() {
             assertEquals(14, DockerStats.getOpenjdkVersionFromString("maven-openjdk14-openj9"))
 
             assertEquals(null, DockerStats.getOpenjdkVersionFromString("official"))
+        }
+    }
+
+    @Test
+    fun packageStatsShouldSumDeltasAcrossMinutes() {
+        runBlocking {
+            val apiPersistenceMock = mockk<ApiPersistence>()
+            val baseTime = TimeSource.now()
+
+            coEvery { apiPersistenceMock.getLatestAllDockerStats() } returns emptyList()
+            coEvery { apiPersistenceMock.getLatestGithubStatsForFeatureVersion(any()) } returns null
+            coEvery { apiPersistenceMock.getPackageStats(any<ZonedDateTime>(), any<ZonedDateTime>()) } returns listOf(
+                // Version 17: three minute-level deltas that should sum to 1000
+                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(3), 400, 17),
+                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(2), 350, 17),
+                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(1), 250, 17),
+                // Version 21: two minute-level deltas that should sum to 500
+                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(2), 300, 21),
+                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(1), 200, 21)
+            )
+
+            val downloadStatsInterface = DownloadStatsInterface(apiPersistenceMock, UpdatableVersionSupplierStub())
+            val stats = downloadStatsInterface.getTotalDownloadStats()
+
+            assertEquals(1500L, stats.total_downloads.package_downloads)
+            assertEquals(1000L, stats.package_downloads[17])
+            assertEquals(500L, stats.package_downloads[21])
         }
     }
 }

--- a/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/DownloadStatsInterfaceTest.kt
+++ b/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/DownloadStatsInterfaceTest.kt
@@ -25,12 +25,9 @@ class DownloadStatsInterfaceTest {
 
             coEvery { apiPersistenceMock.getLatestAllDockerStats() } returns emptyList()
             coEvery { apiPersistenceMock.getLatestGithubStatsForFeatureVersion(any()) } returns null
-            coEvery { apiPersistenceMock.getPackageStats(any<ZonedDateTime>(), any<ZonedDateTime>()) } returns listOf(
-                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(3), 400, 17),
-                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(2), 350, 17),
-                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(1), 250, 17),
-                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(2), 300, 21),
-                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(1), 200, 21)
+            coEvery { apiPersistenceMock.getAggregatedPackageStats(any<ZonedDateTime>(), any<ZonedDateTime>()) } returns listOf(
+                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(1), 1000, 17),
+                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(1), 500, 21)
             )
 
             val downloadStatsInterface = DownloadStatsInterface(apiPersistenceMock, UpdatableVersionSupplierStub())
@@ -57,16 +54,15 @@ class DownloadStatsInterfaceTest {
                 GitHubDownloadStatsDbEntry(baseTime, 200, mapOf(JvmImpl.hotspot to 200L), 8)
             coEvery { apiPersistenceMock.getLatestGithubStatsForFeatureVersion(11) } returns
                 GitHubDownloadStatsDbEntry(baseTime, 100, mapOf(JvmImpl.hotspot to 100L), 11)
-            coEvery { apiPersistenceMock.getPackageStats(any<ZonedDateTime>(), any<ZonedDateTime>()) } returns listOf(
-                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(2), 400, 17),
-                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(1), 600, 17),
+            coEvery { apiPersistenceMock.getAggregatedPackageStats(any<ZonedDateTime>(), any<ZonedDateTime>()) } returns listOf(
+                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(1), 1000, 17),
                 CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(1), 100, 21)
             )
 
             val downloadStatsInterface = DownloadStatsInterface(apiPersistenceMock, UpdatableVersionSupplierStub())
             val stats = downloadStatsInterface.getTotalDownloadStats()
 
-            // Package: 400+600(v17) + 100(v21) = 1100
+            // Package: 1000(v17) + 100(v21) = 1100
             assertEquals(1000L, stats.package_downloads[17])
             assertEquals(100L, stats.package_downloads[21])
             // GitHub: 200(v8) + 100(v11) = 300
@@ -83,7 +79,7 @@ class DownloadStatsInterfaceTest {
 
             coEvery { apiPersistenceMock.getLatestAllDockerStats() } returns emptyList()
             coEvery { apiPersistenceMock.getLatestGithubStatsForFeatureVersion(any()) } returns null
-            coEvery { apiPersistenceMock.getPackageStats(any<ZonedDateTime>(), any<ZonedDateTime>()) } returns emptyList()
+            coEvery { apiPersistenceMock.getAggregatedPackageStats(any<ZonedDateTime>(), any<ZonedDateTime>()) } returns emptyList()
 
             val downloadStatsInterface = DownloadStatsInterface(apiPersistenceMock, UpdatableVersionSupplierStub())
             val stats = downloadStatsInterface.getTotalDownloadStats()

--- a/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/DownloadStatsInterfaceTest.kt
+++ b/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/DownloadStatsInterfaceTest.kt
@@ -1,0 +1,94 @@
+package net.adoptium.api
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import net.adoptium.api.testDoubles.UpdatableVersionSupplierStub
+import net.adoptium.api.v3.DownloadStatsInterface
+import net.adoptium.api.v3.TimeSource
+import net.adoptium.api.v3.dataSources.persitence.ApiPersistence
+import net.adoptium.api.v3.models.CloudflarePackageDownloadStatsDbEntry
+import net.adoptium.api.v3.models.DockerDownloadStatsDbEntry
+import net.adoptium.api.v3.models.GitHubDownloadStatsDbEntry
+import net.adoptium.api.v3.models.JvmImpl
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
+
+class DownloadStatsInterfaceTest {
+
+    @Test
+    fun `package stats should sum delta entries across minutes`() {
+        runBlocking {
+            val apiPersistenceMock = mockk<ApiPersistence>()
+            val baseTime = TimeSource.now()
+
+            coEvery { apiPersistenceMock.getLatestAllDockerStats() } returns emptyList()
+            coEvery { apiPersistenceMock.getLatestGithubStatsForFeatureVersion(any()) } returns null
+            coEvery { apiPersistenceMock.getPackageStats(any<ZonedDateTime>(), any<ZonedDateTime>()) } returns listOf(
+                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(3), 400, 17),
+                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(2), 350, 17),
+                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(1), 250, 17),
+                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(2), 300, 21),
+                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(1), 200, 21)
+            )
+
+            val downloadStatsInterface = DownloadStatsInterface(apiPersistenceMock, UpdatableVersionSupplierStub())
+            val stats = downloadStatsInterface.getTotalDownloadStats()
+
+            assertEquals(1500L, stats.total_downloads.package_downloads)
+            assertEquals(1000L, stats.package_downloads[17])
+            assertEquals(500L, stats.package_downloads[21])
+        }
+    }
+
+    @Test
+    fun `package stats with mixed github and docker should aggregate all sources`() {
+        runBlocking {
+            val apiPersistenceMock = mockk<ApiPersistence>()
+            val baseTime = TimeSource.now()
+
+            // UpdatableVersionSupplierStub.getAllVersions() returns [8, 10, 11, 12, 18]
+            coEvery { apiPersistenceMock.getLatestAllDockerStats() } returns listOf(
+                DockerDownloadStatsDbEntry(baseTime, 500, "eclipse-temurin", null, null)
+            )
+            coEvery { apiPersistenceMock.getLatestGithubStatsForFeatureVersion(any()) } returns null
+            coEvery { apiPersistenceMock.getLatestGithubStatsForFeatureVersion(8) } returns
+                GitHubDownloadStatsDbEntry(baseTime, 200, mapOf(JvmImpl.hotspot to 200L), 8)
+            coEvery { apiPersistenceMock.getLatestGithubStatsForFeatureVersion(11) } returns
+                GitHubDownloadStatsDbEntry(baseTime, 100, mapOf(JvmImpl.hotspot to 100L), 11)
+            coEvery { apiPersistenceMock.getPackageStats(any<ZonedDateTime>(), any<ZonedDateTime>()) } returns listOf(
+                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(2), 400, 17),
+                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(1), 600, 17),
+                CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(1), 100, 21)
+            )
+
+            val downloadStatsInterface = DownloadStatsInterface(apiPersistenceMock, UpdatableVersionSupplierStub())
+            val stats = downloadStatsInterface.getTotalDownloadStats()
+
+            // Package: 400+600(v17) + 100(v21) = 1100
+            assertEquals(1000L, stats.package_downloads[17])
+            assertEquals(100L, stats.package_downloads[21])
+            // GitHub: 200(v8) + 100(v11) = 300
+            // Docker: 500
+            // Total: 300 + 500 + 1100 = 1900
+            assertEquals(1900L, stats.total_downloads.total)
+        }
+    }
+
+    @Test
+    fun `package stats should return zero when no entries exist`() {
+        runBlocking {
+            val apiPersistenceMock = mockk<ApiPersistence>()
+
+            coEvery { apiPersistenceMock.getLatestAllDockerStats() } returns emptyList()
+            coEvery { apiPersistenceMock.getLatestGithubStatsForFeatureVersion(any()) } returns null
+            coEvery { apiPersistenceMock.getPackageStats(any<ZonedDateTime>(), any<ZonedDateTime>()) } returns emptyList()
+
+            val downloadStatsInterface = DownloadStatsInterface(apiPersistenceMock, UpdatableVersionSupplierStub())
+            val stats = downloadStatsInterface.getTotalDownloadStats()
+
+            assertEquals(0L, stats.total_downloads.package_downloads)
+        }
+    }
+}

--- a/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/MongoAPIPersistenceTests.kt
+++ b/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/MongoAPIPersistenceTests.kt
@@ -5,11 +5,13 @@ import net.adoptium.api.v3.TimeSource
 import net.adoptium.api.v3.dataSources.models.GitHubId
 import net.adoptium.api.v3.dataSources.persitence.mongo.MongoApiPersistence
 import net.adoptium.api.v3.dataSources.persitence.mongo.MongoClient
+import net.adoptium.api.v3.models.CloudflarePackageDownloadStatsDbEntry
 import net.adoptium.api.v3.models.GHReleaseMetadata
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class MongoAPIPersistenceTests : MongoTest() {
+
     @Test
     fun `update time is set`(api: MongoApiPersistence) {
         runBlocking {
@@ -52,6 +54,68 @@ class MongoAPIPersistenceTests : MongoTest() {
 
 
             assertEquals(metadata, saved)
+        }
+    }
+
+    @Test
+    fun `getAggregatedPackageStats should sum downloads and return max date per feature version`() {
+        runBlocking {
+            val apiPersistence = MongoApiPersistence(MongoClient())
+            val baseTime = TimeSource.now()
+
+            // Clean up any leftover data from previous tests
+            apiPersistence.removeStatsBetween(baseTime.minusDays(1), baseTime.plusDays(1))
+
+            apiPersistence.addPackageDownloadStatsEntries(
+                listOf(
+                    CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(3), 400, 17),
+                    CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(2), 350, 17),
+                    CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(1), 250, 17),
+                    CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(2), 300, 21),
+                    CloudflarePackageDownloadStatsDbEntry(baseTime.minusMinutes(1), 200, 21)
+                )
+            )
+
+            val start = baseTime.minusDays(1)
+            val end = baseTime.plusDays(1)
+
+            val aggregated = apiPersistence.getAggregatedPackageStats(start, end)
+                .sortedBy { it.feature_version }
+
+            assertEquals(2, aggregated.size)
+
+            val v17 = aggregated.find { it.feature_version == 17 }!!
+            assertEquals(1000L, v17.downloads)
+            assertEquals(baseTime.minusMinutes(1), v17.date)
+
+            val v21 = aggregated.find { it.feature_version == 21 }!!
+            assertEquals(500L, v21.downloads)
+            assertEquals(baseTime.minusMinutes(1), v21.date)
+        }
+    }
+
+    @Test
+    fun `getAggregatedPackageStats should return empty list when no data matches date range`() {
+        runBlocking {
+            val apiPersistence = MongoApiPersistence(MongoClient())
+            val baseTime = TimeSource.now()
+
+            // Use a date far in the future to avoid colliding with other tests
+            val farFuture = baseTime.plusYears(10)
+
+            apiPersistence.addPackageDownloadStatsEntries(
+                listOf(
+                    CloudflarePackageDownloadStatsDbEntry(farFuture, 100, 17)
+                )
+            )
+
+            // Query a range that doesn't overlap with the data
+            val start = baseTime.minusDays(30)
+            val end = baseTime.minusDays(10)
+
+            val aggregated = apiPersistence.getAggregatedPackageStats(start, end)
+
+            assertEquals(0, aggregated.size)
         }
     }
 }

--- a/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/testDoubles/InMemoryApiPersistence.kt
+++ b/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/testDoubles/InMemoryApiPersistence.kt
@@ -107,6 +107,18 @@ open class InMemoryApiPersistence @Inject constructor(var repos: AdoptRepos, var
             .sortedBy { it.date }
     }
 
+    override suspend fun getAggregatedPackageStats(start: ZonedDateTime, end: ZonedDateTime): List<CloudflarePackageDownloadStatsDbEntry> {
+        return getPackageStats(start, end)
+            .groupBy { it.feature_version }
+            .map { (version, entries) ->
+                CloudflarePackageDownloadStatsDbEntry(
+                    date = entries.maxOf { it.date },
+                    downloads = entries.sumOf { it.downloads },
+                    feature_version = version
+                )
+            }
+    }
+
     override suspend fun removeStatsBetween(start: ZonedDateTime, end: ZonedDateTime) {
         githubStats.removeIf { it.date.isAfter(start) && it.date.isBefore(end) }
         dockerStats.removeIf { it.date.isAfter(start) && it.date.isBefore(end) }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

On PR #1832 we introduced package download stats but cloudflare api returns data by minute, so we don't have snapshots. When reading the _latest_ we have to scan the full DB. This is the minimum code. I was hesitant to add a cache because I am not sure how this is deployed, the options are:
- A) Trust DB cache will handle subsequent reads (I am not sure how well mongo performs here)
- B) Add a local cache, only usefull if you have limited number of instances.
- C) Build and update snapshots of cloudflare date after writing, as a post-processing job

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] You added tests to cover the change
- [x] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation