### PR TITLE
Update CDXA incrementalUpdate to use lastModified as CDXA committedDate

### DIFF
--- a/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/dataSources/APIDataStoreImpl.kt
+++ b/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/dataSources/APIDataStoreImpl.kt
@@ -84,7 +84,8 @@ open class APIDataStoreImpl : APIDataStore {
                     val data = dataStore.readCdxaData()
                     val updatedAt = dataStore.getCdxaUpdatedAt()
 
-                    val newData = AdoptCdxaRepos(data)
+                    val lastModified = updatedAt.lastModified?.toInstant()
+                    val newData = AdoptCdxaRepos(data, lastModified)
 
                     if (logEntries) {
                         LOGGER.info("Loaded Cdxas: $updatedAt")

--- a/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/dataSources/persitence/mongo/MongoApiPersistence.kt
+++ b/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/dataSources/persitence/mongo/MongoApiPersistence.kt
@@ -32,6 +32,7 @@ import org.bson.BsonDocument
 import org.bson.BsonString
 import org.bson.Document
 import org.slf4j.LoggerFactory
+import java.time.Instant
 import java.time.ZonedDateTime
 
 @ApplicationScoped
@@ -101,7 +102,7 @@ open class MongoApiPersistence @Inject constructor(mongoClient: MongoClient) : M
 
             removeCdxasNotInFeatureVersions(featureVersions)
         } finally {
-            updateCdxaUpdatedTime(TimeSource.now(), checksum, repo.hashCode())
+            updateCdxaUpdatedTime(TimeSource.now(), checksum, repo.hashCode(), repo.lastModified)
         }
     }
 
@@ -273,10 +274,11 @@ open class MongoApiPersistence @Inject constructor(mongoClient: MongoClient) : M
         updateTimeCollection.deleteMany(Document("time", BsonDocument("\$lt", BsonDateTime(dateTime.toInstant().toEpochMilli()))))
     }
 
-    open suspend fun updateCdxaUpdatedTime(dateTime: ZonedDateTime, checksum: String, hashCode: Int) {
+    open suspend fun updateCdxaUpdatedTime(dateTime: ZonedDateTime, checksum: String, hashCode: Int, lastModified: Instant? = null) {
+        val lastModifiedDate = lastModified?.let { java.util.Date.from(it) }
         cdxaUpdateTimeCollection.replaceOne(
             Document(),
-            UpdatedInfo(dateTime, checksum, hashCode),
+            UpdatedInfo(dateTime, checksum, hashCode, lastModifiedDate),
             ReplaceOptions().upsert(true)
         )
         cdxaUpdateTimeCollection.deleteMany(Document("time", BsonDocument("\$lt", BsonDateTime(dateTime.toInstant().toEpochMilli()))))

--- a/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/dataSources/persitence/mongo/UpdatedInfo.kt
+++ b/adoptium-api-v3-persistence/src/main/kotlin/net/adoptium/api/v3/dataSources/persitence/mongo/UpdatedInfo.kt
@@ -18,6 +18,6 @@ data class UpdatedInfo(
         ?.format(DateTimeFormatter.RFC_1123_DATE_TIME)) {
 
     override fun toString(): String {
-        return "$time $checksum $hashCode"
+        return "$time $checksum $hashCode $lastModified"
     }
 }

--- a/adoptium-models-parent/adoptium-api-v3-models/src/main/kotlin/net/adoptium/api/v3/dataSources/models/AdoptCdxaRepos.kt
+++ b/adoptium-models-parent/adoptium-api-v3-models/src/main/kotlin/net/adoptium/api/v3/dataSources/models/AdoptCdxaRepos.kt
@@ -13,19 +13,24 @@ import net.adoptium.api.v3.models.OperatingSystem
 import net.adoptium.api.v3.models.Project
 import net.adoptium.api.v3.models.Vendor
 import net.adoptium.api.v3.models.Cdxa
+import java.time.Instant
 import java.time.ZonedDateTime
 import java.util.function.Predicate
 
 class AdoptCdxaRepos {
 
     val repos: List<Cdxa>
+    val lastModified: Instant?  // Set to the "latest" committedDate of cdxas, to enable incrementalUpdate to determine changes
 
     @JsonCreator
     constructor(
         @JsonProperty("repos")
-        repos: List<Cdxa>
+        repos: List<Cdxa>,
+        @JsonProperty("lastModified")
+        lastModified: Instant? = null
     ) {
         this.repos = repos
+        this.lastModified = lastModified
     }
 
     fun getCdxas(): List<Cdxa> {
@@ -76,15 +81,15 @@ class AdoptCdxaRepos {
 
     fun addCdxa(att: Cdxa): AdoptCdxaRepos {
         val updated = repos + att
-        return AdoptCdxaRepos(updated)
+        return AdoptCdxaRepos(updated, lastModified)
     }
 
     fun removeCdxa(att: Cdxa): AdoptCdxaRepos {
         val updated = repos.filter { it.id != att.id }
-        return AdoptCdxaRepos(updated)
+        return AdoptCdxaRepos(updated, lastModified)
     }
 
-    fun removeCdxais(cdxas: List<Cdxa>): AdoptCdxaRepos {
+    fun removeCdxas(cdxas: List<Cdxa>): AdoptCdxaRepos {
         if (cdxas.isEmpty()) {
             return this
         }
@@ -98,10 +103,15 @@ class AdoptCdxaRepos {
 
         other as AdoptCdxaRepos
 
-        return repos == other.repos
+        if (repos != other.repos) return false
+        if (lastModified != other.lastModified) return false
+
+        return true
     }
 
     override fun hashCode(): Int {
-        return repos.hashCode()
+        var result = repos.hashCode()
+        result = 31 * result + (lastModified?.hashCode() ?: 0)
+        return result
     }
 }

--- a/adoptium-updater-parent/adoptium-api-v3-updater/src/main/kotlin/net/adoptium/api/v3/AdoptCdxaRepoBuilders.kt
+++ b/adoptium-updater-parent/adoptium-api-v3-updater/src/main/kotlin/net/adoptium/api/v3/AdoptCdxaRepoBuilders.kt
@@ -26,17 +26,17 @@ class AdoptCdxaReposBuilder @Inject constructor(
     }
 
     suspend fun build(): AdoptCdxaRepos {
-        val cdxas = adoptCdxaRepository.getCdxas()
-        LOGGER.info("DONE cdxa build")
-        return AdoptCdxaRepos(cdxas)
+        val (cdxas, lastModified) = adoptCdxaRepository.getCdxas()
+        LOGGER.info("DONE cdxa build, lastModified: $lastModified")
+        return AdoptCdxaRepos(cdxas, lastModified)
     }
 
     suspend fun incrementalUpdate(
         oldRepo: AdoptCdxaRepos,
         lastUpdatedAt: UpdatedInfo
     ): AdoptCdxaRepos {
-        val cdxas = adoptCdxaRepository.incrementalUpdate(oldRepo, lastUpdatedAt)
-        LOGGER.info("DONE cdxa incrementalUpdate")
-        return AdoptCdxaRepos(cdxas)
+        val (cdxas, lastModified) = adoptCdxaRepository.incrementalUpdate(oldRepo, lastUpdatedAt)
+        LOGGER.info("DONE cdxa incrementalUpdate, lastModified: $lastModified")
+        return AdoptCdxaRepos(cdxas, lastModified)
     }
 }

--- a/adoptium-updater-parent/adoptium-api-v3-updater/src/main/kotlin/net/adoptium/api/v3/AdoptCdxaRepository.kt
+++ b/adoptium-updater-parent/adoptium-api-v3-updater/src/main/kotlin/net/adoptium/api/v3/AdoptCdxaRepository.kt
@@ -23,9 +23,9 @@ import org.slf4j.LoggerFactory
 import java.time.Instant
 
 interface AdoptCdxaRepository {
-    suspend fun getCdxas(): List<Cdxa>
+    suspend fun getCdxas(): Pair<List<Cdxa>, Instant?>
     suspend fun getCdxaByName(vendor: Vendor, owner: String, repoName: String, name: String) : Cdxa?
-    suspend fun incrementalUpdate(oldRepo: AdoptCdxaRepos, lastUpdatedAt: UpdatedInfo): List<Cdxa>
+    suspend fun incrementalUpdate(oldRepo: AdoptCdxaRepos, lastUpdatedAt: UpdatedInfo): Pair<List<Cdxa>, Instant?>
 }
 
 @ApplicationScoped
@@ -69,12 +69,13 @@ open class AdoptCdxaRepositoryImpl @Inject constructor(
         }
     }
 
-    private fun getRepository(): suspend (Vendor, String, String) -> List<Cdxa> {
+    private fun getRepository(): suspend (Vendor, String, String) -> Pair<List<Cdxa>, Instant?> {
         return { vendor: Vendor, owner: String, repoName: String -> getRepository(vendor, owner, repoName) }
     }
 
-    private suspend fun getRepository(vendor: Vendor, owner: String, repoName: String): List<Cdxa> {
+    private suspend fun getRepository(vendor: Vendor, owner: String, repoName: String): Pair<List<Cdxa>, Instant?> {
         val cdxas = mutableListOf<Cdxa>()
+        var latestCommittedDate: Instant? = null
 
         LOGGER.info("Cdxa getRepository for: " + vendor + " " + owner + "/" + repoName)
 
@@ -98,15 +99,22 @@ open class AdoptCdxaRepositoryImpl @Inject constructor(
 
         // Get the Cdxas for each major version
         for( majorVersion in majorVersions ) {
-          cdxas.addAll( getCdxasForVersion( vendor, owner, repoName, majorVersion, null ) )
+          val (versionCdxas, versionLatestDate) = getCdxasForVersion( vendor, owner, repoName, majorVersion, null )
+          cdxas.addAll( versionCdxas )
+
+          // Track the latest committedDate across all versions
+          if (versionLatestDate != null && (latestCommittedDate == null || versionLatestDate.isAfter(latestCommittedDate))) {
+              latestCommittedDate = versionLatestDate
+          }
         }
 
-        return cdxas
+        return Pair(cdxas, latestCommittedDate)
     }
 
-    private suspend fun getCdxasForVersion(vendor: Vendor, owner: String, repoName: String, version: Int, afterDate: Instant?): List<Cdxa> {
+    private suspend fun getCdxasForVersion(vendor: Vendor, owner: String, repoName: String, version: Int, afterDate: Instant?): Pair<List<Cdxa>, Instant?> {
         LOGGER.info("getCdxasForVersion: "+vendor+" "+owner+" "+repoName+" "+version+" modifiedAfterDate: "+afterDate)
         val cdxas = mutableListOf<GHCdxa>()
+        var latestCommittedDate: Instant? = null
 
         val attSummaryTags = client.getCdxaSummary(owner, repoName, "$version")
         if ( attSummaryTags != null ) {
@@ -121,6 +129,11 @@ open class AdoptCdxaRepositoryImpl @Inject constructor(
                 if ( attEntries?.repository?.att_object?.entries != null) {
                   // Get last commit update date for this releaseTag
                   var committedDate = instantFromCommittedDate( owner, repoName, attEntries?.repository?.defaultBranchRef?.target?.history?.nodes?.firstOrNull()?.committedDate )
+
+                  // Track the latest committedDate across all release tags
+                  if (committedDate != null && (latestCommittedDate == null || committedDate.isAfter(latestCommittedDate))) {
+                      latestCommittedDate = committedDate
+                  }
 
                   // Have cdxas for this release being updated?
                   if ( afterDate == null || committedDate == null || committedDate.isAfter(afterDate) ) {
@@ -142,7 +155,7 @@ open class AdoptCdxaRepositoryImpl @Inject constructor(
           }
         }
 
-        return getMapperForRepo(owner + "/" + repoName + "/").toCdxaList(vendor, cdxas)
+        return Pair(getMapperForRepo(owner + "/" + repoName + "/").toCdxaList(vendor, cdxas), latestCommittedDate)
     }
 
     private fun getSummaries(): suspend (Vendor, String, String) -> List<CdxaRepoVersionSummary> {
@@ -197,19 +210,33 @@ open class AdoptCdxaRepositoryImpl @Inject constructor(
     override suspend fun incrementalUpdate(
         oldRepo: AdoptCdxaRepos,
         lastUpdatedAt: UpdatedInfo
-    ): List<Cdxa> {
+    ): Pair<List<Cdxa>, Instant?> {
 
         val summaries: List<CdxaRepoVersionSummary> = getDataForEachRepo(
             getSummaries()
         ).await().flatMap { it.toList() }
 
         var updatedCdxas = oldRepo.repos.toMutableList()
-        for( summary in summaries ) {
-            if ( summary.committedDate == null || (summary.committedDate as Instant).isAfter( lastUpdatedAt.time.toInstant() ) ) {
-                LOGGER.info("incrementalUpdate: version has been updated: "+summary)
+        var latestCommittedDate: Instant? = null
+        var hasUpdates = false
 
-                // Get Cdxas for version releaseTags that have been updated after lastUpdatedAt
-                val cdxas = getCdxasForVersion( summary.vendor, summary.org, summary.repo, summary.featureVersion, lastUpdatedAt.time.toInstant() )
+        // Use lastModified from UpdatedInfo if available, otherwise fall back to time
+        val lastModifiedInstant = lastUpdatedAt.lastModified?.toInstant() ?: lastUpdatedAt.time.toInstant()
+
+        for( summary in summaries ) {
+            // Is this Cdxa folder "committedDate" after the current AdoptCdxaRepos lastUpdatedAt.lastModified ?
+            //   ie.has a new commit being merged into this folder?
+            if ( summary.committedDate == null || (summary.committedDate as Instant).isAfter( lastModifiedInstant ) ) {
+                LOGGER.info("incrementalUpdate: version has been updated: "+summary)
+                hasUpdates = true
+
+                // Get Cdxas for version releaseTags that have been updated after lastModified
+                val (cdxas, versionLatestDate) = getCdxasForVersion( summary.vendor, summary.org, summary.repo, summary.featureVersion, lastModifiedInstant )
+
+                // Track the latest committedDate
+                if (versionLatestDate != null && (latestCommittedDate == null || versionLatestDate.isAfter(latestCommittedDate))) {
+                    latestCommittedDate = versionLatestDate
+                }
 
                 val updatedReleases = cdxas.map { it.release_name }.distinct()
 
@@ -226,16 +253,27 @@ open class AdoptCdxaRepositoryImpl @Inject constructor(
         val currentVersions = summaries.map { it.featureVersion }.distinct()
         updatedCdxas.removeAll { it.featureVersion !in currentVersions }
 
-        return updatedCdxas
+        // If no versions were modified, preserve the old repo's lastModified to maintain equality
+        // Otherwise, use the new latestCommittedDate or fall back to lastModifiedInstant
+        val finalLastModified = if (!hasUpdates) {
+            oldRepo.lastModified
+        } else {
+            latestCommittedDate ?: lastModifiedInstant
+        }
+
+        return Pair(updatedCdxas, finalLastModified)
     }
 
-    override suspend fun getCdxas(): List<Cdxa> {
+    override suspend fun getCdxas(): Pair<List<Cdxa>, Instant?> {
         
-        val cdxas: List<Cdxa> = getDataForEachRepo(
+        val results: List<Pair<List<Cdxa>, Instant?>> = getDataForEachRepo(
             getRepository()
-        ).await().flatMap { it.toList() }
+        ).await()
+
+        val cdxas = results.flatMap { it.first }
+        val latestCommittedDate = results.mapNotNull { it.second }.maxOrNull()
                 
-        return cdxas
+        return Pair(cdxas, latestCommittedDate)
     }
 
     private fun <E> getDataForEachRepo(

--- a/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/AdoptCdxaReposTestDataGenerator.kt
+++ b/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/AdoptCdxaReposTestDataGenerator.kt
@@ -11,10 +11,13 @@ import net.adoptium.api.v3.models.Vendor
 import net.adoptium.api.v3.models.Cdxa
 import java.util.*
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 object AdoptCdxaReposTestDataGenerator {
 
     var rand: Random = Random(1)
+    val FIXED_TIMESTAMP = Instant.parse("2026-01-01T00:00:00Z").truncatedTo(ChronoUnit.MILLIS)
+
     private val TEST_RESOURCES = listOf(
         Cdxa(randomString("cdxa id"),
                     "21/jdk-21.0.5+6/cdxa_jdk-21.0.5+6.xml",
@@ -34,7 +37,7 @@ object AdoptCdxaReposTestDataGenerator {
                     "VERIFICATION_LOG",
                     "log",
                     "Build verification completed: 100% reproducible for jdk-21.0.5+6",
-                    Instant.now()),
+                    FIXED_TIMESTAMP),
         Cdxa(randomString("cdxa id"),
                     "21/jdk-21.0.5+6/cdxa_jdk-21.0.5+6_other.xml",
                     21,
@@ -53,7 +56,7 @@ object AdoptCdxaReposTestDataGenerator {
                     "VERIFICATION_LOG",
                     "log",
                     "Alternative verification: Binary comparison successful for jdk-21.0.5+6",
-                    Instant.now()),
+                    FIXED_TIMESTAMP),
         Cdxa(randomString("cdxa id"),
                     "21/jdk-21.0.6+8/cdxa_jdk-21.0.6+8.xml",
                     21,
@@ -72,7 +75,7 @@ object AdoptCdxaReposTestDataGenerator {
                     "VERIFICATION_LOG",
                     "log",
                     "Reproducible build verified for aarch64 architecture jdk-21.0.6+8",
-                    Instant.now()),
+                    FIXED_TIMESTAMP),
         Cdxa(randomString("cdxa id"),
                     "23/jdk-23.0.1+6/cdxa_jdk-23.0.1+6.xml",
                     23,
@@ -91,7 +94,7 @@ object AdoptCdxaReposTestDataGenerator {
                     "VERIFICATION_LOG",
                     "log",
                     "JDK 23 build verification: All artifacts match reference build",
-                    Instant.now()),
+                    FIXED_TIMESTAMP),
         Cdxa(randomString("cdxa id"),
                     "24/jdk-24.0.2+12/cdxa_jdk-24.0.2+12.xml",
                     24,
@@ -110,7 +113,7 @@ object AdoptCdxaReposTestDataGenerator {
                     "VERIFICATION_LOG",
                     "log",
                     "macOS build verification complete: Reproducible build confirmed for jdk-24.0.2+12",
-                    Instant.now()),
+                    FIXED_TIMESTAMP),
         Cdxa(randomString("cdxa id"),
                     "11/jdk-11.0.21+8/cdxa_jdk-11.0.21+8.xml",
                     11,
@@ -129,13 +132,17 @@ object AdoptCdxaReposTestDataGenerator {
                     "VERIFICATION_LOG",
                     "log",
                     "Windows x64 verification: LTS build jdk-11.0.21+8 successfully reproduced",
-                    Instant.now())
+                    FIXED_TIMESTAMP)
     )
 
     fun generate(): AdoptCdxaRepos {
         rand = Random(1)
 
-        val repo = AdoptCdxaRepos(TEST_RESOURCES)
+        // Set lastModified to the latest committedDate from the test resources
+        val latestCommittedDate: Instant? = TEST_RESOURCES
+            .map { it.committedDate }
+            .maxWithOrNull(compareBy { it })
+        val repo = AdoptCdxaRepos(TEST_RESOURCES, latestCommittedDate)
 
         return repo
     }

--- a/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/GHCdxaSummaryTestDataGenerator.kt
+++ b/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/GHCdxaSummaryTestDataGenerator.kt
@@ -64,10 +64,12 @@ object GHCdxaSummaryTestDataGenerator {
           }
         }
 
+        // Use the lastModified from the repo, or fall back to a default timestamp
+        val committedDate = repo.lastModified?.toString() ?: "2025-01-06T10:30:00Z"
         val defaultBranchRef = GHCdxaRepoSummaryDefaultBranchRef(
-                                 GHCdxaRepoSummaryDefaultBranchRefTarget(
-                                   GHCdxaRepoSummaryDefaultBranchRefHistory(
-                                     listOf(GHCdxaRepoSummaryDefaultBranchRefNode("2025-01-06T10:30:00Z")))))
+                                  GHCdxaRepoSummaryDefaultBranchRefTarget(
+                                    GHCdxaRepoSummaryDefaultBranchRefHistory(
+                                     listOf(GHCdxaRepoSummaryDefaultBranchRefNode(committedDate)))))
 
         val cdxaSummary = GHCdxaRepoSummaryData(GHCdxaRepoSummaryRepository(defaultBranchRef, GHCdxaRepoSummaryObject(summaries)), RateLimit(1,1000))
 

--- a/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/V3UpdaterEndToEndTest.kt
+++ b/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/V3UpdaterEndToEndTest.kt
@@ -212,8 +212,8 @@ class V3UpdaterEndToEndTest {
     @Test   
     fun `new cdxa is added`() {
         runBlocking {
-            val new_committedDate_str = "2026-02-01T00:00:00Z"
-            val new_committedDate = Instant.parse(new_committedDate_str).truncatedTo(ChronoUnit.MILLIS)
+            val newCommittedDateStr = "2026-02-01T00:00:00Z"
+            val newCommittedDate = Instant.parse(newCommittedDateStr).truncatedTo(ChronoUnit.MILLIS)
 
             val cdxaRepo = AdoptCdxaReposTestDataGenerator.generate()
 
@@ -232,7 +232,7 @@ class V3UpdaterEndToEndTest {
 
                 // If directory covers new 24/jdk-24.0.2+12, then set committedDate summary to be for the new entry added
                 if ( (directory == "" || directory == "24" || directory == "24/jdk-24.0.2+12") && cdxaSummary?.repository?.att_object?.entries != null ) {
-                    cdxaSummary?.repository?.defaultBranchRef?.target?.history?.nodes?.firstOrNull()?.committedDate = new_committedDate_str
+                    cdxaSummary?.repository?.defaultBranchRef?.target?.history?.nodes?.firstOrNull()?.committedDate = newCommittedDateStr
                 }
 
                 LOGGER.info("getCdxaSummary: "+cdxaSummary)
@@ -309,7 +309,7 @@ class V3UpdaterEndToEndTest {
                                 var evidences: Evidences = Evidences(listOf(evidence))
                                 var d: Declarations = Declarations(ass, cls, evidences, null, Targets(cs), aff)
 
-                                GHCdxa( GitHubId("1"), name, "https://github.com/"+org+"/"+repo+"/blob/main/"+name, "https://github.com/"+org+"/"+repo+"/blob/main/"+name+".sig", new_committedDate, d, null)
+                                GHCdxa( GitHubId("1"), name, "https://github.com/"+org+"/"+repo+"/blob/main/"+name, "https://github.com/"+org+"/"+repo+"/blob/main/"+name+".sig", newCommittedDate, d, null)
                             } else {
                                 null
                             }
@@ -317,9 +317,9 @@ class V3UpdaterEndToEndTest {
 
             val updatedRepo = runCdxaUpdateTest(cdxaRepo, getCdxaSummary, getCdxaByName)
 
-            // Check lastModified gets updated to the "latest" lastComittedDate of the cdxas
+            // Check lastModified gets updated to the "latest" lastCommittedDate of the cdxas
             assertTrue(cdxaRepo.lastModified == AdoptCdxaReposTestDataGenerator.FIXED_TIMESTAMP)
-            assertTrue(updatedRepo.lastModified == new_committedDate)
+            assertTrue(updatedRepo.lastModified == newCommittedDate)
 
             assertTrue(updatedRepo.repos.size == cdxaRepo.repos.size + 1)
             val addedAtt = updatedRepo.repos.firstOrNull { it.filename == "24/jdk-24.0.2+12/jdk_24_0_2_12_aarch64_linux_Adoptium.xml" }

--- a/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/V3UpdaterEndToEndTest.kt
+++ b/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/V3UpdaterEndToEndTest.kt
@@ -69,6 +69,7 @@ import org.junit.jupiter.api.Test
 import java.util.concurrent.atomic.AtomicBoolean
 import org.slf4j.LoggerFactory
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 class V3UpdaterEndToEndTest {
 
@@ -211,6 +212,9 @@ class V3UpdaterEndToEndTest {
     @Test   
     fun `new cdxa is added`() {
         runBlocking {
+            val new_committedDate_str = "2026-02-01T00:00:00Z"
+            val new_committedDate = Instant.parse(new_committedDate_str).truncatedTo(ChronoUnit.MILLIS)
+
             val cdxaRepo = AdoptCdxaReposTestDataGenerator.generate()
 
             val getCdxaSummary: ((String, String, String) -> GHCdxaRepoSummaryData?) = { org, repo , directory ->
@@ -224,6 +228,11 @@ class V3UpdaterEndToEndTest {
                                                                                      GHCdxaRepoSummaryEntry("jdk_24_0_2_12_aarch64_linux_Adoptium.xml",
                                                                                                                    "blob"
                                                                                                                   )
+                }
+
+                // If directory covers new 24/jdk-24.0.2+12, then set committedDate summary to be for the new entry added
+                if ( (directory == "" || directory == "24" || directory == "24/jdk-24.0.2+12") && cdxaSummary?.repository?.att_object?.entries != null ) {
+                    cdxaSummary?.repository?.defaultBranchRef?.target?.history?.nodes?.firstOrNull()?.committedDate = new_committedDate_str
                 }
 
                 LOGGER.info("getCdxaSummary: "+cdxaSummary)
@@ -300,13 +309,17 @@ class V3UpdaterEndToEndTest {
                                 var evidences: Evidences = Evidences(listOf(evidence))
                                 var d: Declarations = Declarations(ass, cls, evidences, null, Targets(cs), aff)
 
-                                GHCdxa( GitHubId("1"), name, "https://github.com/"+org+"/"+repo+"/blob/main/"+name, "https://github.com/"+org+"/"+repo+"/blob/main/"+name+".sig", Instant.now(), d, null)
+                                GHCdxa( GitHubId("1"), name, "https://github.com/"+org+"/"+repo+"/blob/main/"+name, "https://github.com/"+org+"/"+repo+"/blob/main/"+name+".sig", new_committedDate, d, null)
                             } else {
                                 null
                             }
             }
 
             val updatedRepo = runCdxaUpdateTest(cdxaRepo, getCdxaSummary, getCdxaByName)
+
+            // Check lastModified gets updated to the "latest" lastComittedDate of the cdxas
+            assertTrue(cdxaRepo.lastModified == AdoptCdxaReposTestDataGenerator.FIXED_TIMESTAMP)
+            assertTrue(updatedRepo.lastModified == new_committedDate)
 
             assertTrue(updatedRepo.repos.size == cdxaRepo.repos.size + 1)
             val addedAtt = updatedRepo.repos.firstOrNull { it.filename == "24/jdk-24.0.2+12/jdk_24_0_2_12_aarch64_linux_Adoptium.xml" }

--- a/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/testDoubles/InMemoryApiPersistence.kt
+++ b/adoptium-updater-parent/adoptium-api-v3-updater/src/test/kotlin/net/adoptium/api/testDoubles/InMemoryApiPersistence.kt
@@ -16,6 +16,7 @@ import net.adoptium.api.v3.models.ReleaseInfo
 import net.adoptium.api.v3.models.Vendor
 import net.adoptium.api.v3.models.Cdxa
 import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
 import jakarta.annotation.Priority
 import jakarta.enterprise.inject.Alternative
 import jakarta.inject.Inject
@@ -42,7 +43,8 @@ open class InMemoryApiPersistence @Inject constructor(var repos: AdoptRepos, var
 
     override suspend fun updateCdxaRepos(repos: AdoptCdxaRepos, checksum: String) {
         this.cdxaRepos = repos
-        this.cdxaUpdatedAtInfo = UpdatedInfo(TimeSource.now(), checksum, repos.hashCode())
+        val lastModifiedDate = repos.lastModified?.let { java.util.Date.from(it) }
+        this.cdxaUpdatedAtInfo = UpdatedInfo(TimeSource.now(), checksum, repos.hashCode(), lastModifiedDate)
     }
 
     override suspend fun readCdxaData(): List<Cdxa> {

--- a/adoptium-updater-parent/adoptium-datasources-parent/adoptium-github-datasource/src/main/kotlin/net/adoptium/api/v3/dataSources/github/graphql/models/GHCdxaResponse.kt
+++ b/adoptium-updater-parent/adoptium-datasources-parent/adoptium-github-datasource/src/main/kotlin/net/adoptium/api/v3/dataSources/github/graphql/models/GHCdxaResponse.kt
@@ -104,7 +104,7 @@ data class GHCdxaResponseObject @JsonCreator constructor(
     @JsonProperty("id")
     @JsonDeserialize(using = GitHubIdDeserializer::class)
     val id: GitHubId,
-    @JsonProperty("text")   val text: String
+    @JsonProperty("text")   val text: String? = null
 ) { 
 }
 

--- a/adoptium-updater-parent/adoptium-mappers-parent/adopt-mappers/src/main/kotlin/net/adoptium/api/v3/mapping/adopt/AdoptCdxaMapper.kt
+++ b/adoptium-updater-parent/adoptium-mappers-parent/adopt-mappers/src/main/kotlin/net/adoptium/api/v3/mapping/adopt/AdoptCdxaMapper.kt
@@ -114,7 +114,7 @@ private class AdoptCdxaMapper(
                                          vendor, target_checksum, assessor_org, assessor_affirmation, assessor_claim_predicate,
                                          ghCdxaAsset.linkUrl?:"", ghCdxaAsset.linkSigUrl?:"",
                                          evidence_propertyName, evidence_data_name, evidence_data_contents_attachment_text,
-                                         ghCdxaAsset.committedDate?: Instant.now().truncatedTo(ChronoUnit.MILLIS))
+                                         (ghCdxaAsset.committedDate ?: Instant.now()).truncatedTo(ChronoUnit.MILLIS))
             } catch (e: java.lang.Exception) {
                 LOGGER.error("Exception mapping cdxa : "+e+" GHCdxa: "+ghCdxaAsset)
                 return@async null

--- a/adoptium-updater-parent/adoptium-mappers-parent/adopt-mappers/src/main/kotlin/net/adoptium/api/v3/mapping/adopt/AdoptCdxaMapper.kt
+++ b/adoptium-updater-parent/adoptium-mappers-parent/adopt-mappers/src/main/kotlin/net/adoptium/api/v3/mapping/adopt/AdoptCdxaMapper.kt
@@ -17,7 +17,7 @@ import net.adoptium.api.v3.mapping.CdxaMapper
 import org.slf4j.LoggerFactory
 import java.util.EnumMap
 import java.time.Instant
-
+import java.time.temporal.ChronoUnit
 
 @ApplicationScoped
 open class AdoptCdxaMapperFactory @Inject constructor(
@@ -114,7 +114,7 @@ private class AdoptCdxaMapper(
                                          vendor, target_checksum, assessor_org, assessor_affirmation, assessor_claim_predicate,
                                          ghCdxaAsset.linkUrl?:"", ghCdxaAsset.linkSigUrl?:"",
                                          evidence_propertyName, evidence_data_name, evidence_data_contents_attachment_text,
-                                         ghCdxaAsset.committedDate?: Instant.now())
+                                         ghCdxaAsset.committedDate?: Instant.now().truncatedTo(ChronoUnit.MILLIS))
             } catch (e: java.lang.Exception) {
                 LOGGER.error("Exception mapping cdxa : "+e+" GHCdxa: "+ghCdxaAsset)
                 return@async null


### PR DESCRIPTION
Fixes https://github.com/adoptium/api.adoptium.net/issues/1942

Two fixes:
- Make "text" field of CDXA github QL query nullable, so CDXA query can check existence for the .xml.sig file, even if it is a binary signature file
- Change CDXA updatedAt.lastModified to be the "latest" CDXA commitedDate, so that CDXA incrementalUpdate can be made to work using the latest committedDate from the github CDXA version folder queries.

Assisted-by: IBM Bob

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] You added tests to cover the change
- [x] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation